### PR TITLE
feat: 일반 로그인 및 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	runtimeOnly 'com.h2database:h2'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	// jwt
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'

--- a/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
+++ b/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.hamster.gro_up.controller;
+
+import com.hamster.gro_up.dto.ApiResponse;
+import com.hamster.gro_up.dto.request.SigninRequest;
+import com.hamster.gro_up.dto.request.SignupRequest;
+import com.hamster.gro_up.dto.response.TokenResponse;
+import com.hamster.gro_up.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ApiResponse<TokenResponse> signup(@RequestBody SignupRequest signupRequest) {
+        TokenResponse response = authService.signup(signupRequest);
+        return ApiResponse.ok(response);
+    }
+
+    @PostMapping("/siginin")
+    public ApiResponse<TokenResponse> signin(@RequestBody SigninRequest signinRequest) {
+        TokenResponse response = authService.signin(signinRequest);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/hamster/gro_up/dto/request/SigninRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/SigninRequest.java
@@ -1,0 +1,13 @@
+package com.hamster.gro_up.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SigninRequest {
+
+    private String email;
+
+    private String password;
+}

--- a/src/main/java/com/hamster/gro_up/dto/request/SignupRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/SignupRequest.java
@@ -1,0 +1,15 @@
+package com.hamster.gro_up.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class SignupRequest {
+
+    private String email;
+
+    private String name;
+
+    private String password;
+}

--- a/src/main/java/com/hamster/gro_up/dto/response/TokenResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/TokenResponse.java
@@ -1,0 +1,10 @@
+package com.hamster.gro_up.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenResponse {
+    private String token;
+}

--- a/src/main/java/com/hamster/gro_up/entity/User.java
+++ b/src/main/java/com/hamster/gro_up/entity/User.java
@@ -16,15 +16,18 @@ public class User {
 
     private String email;
 
+    private String password;
+
     private String name;
 
     @Enumerated(EnumType.STRING)
     private Role role;
 
     @Builder
-    public User(Long id, String email, String name, Role role) {
+    public User(Long id, String email, String password, String name, Role role) {
         this.id = id;
         this.email = email;
+        this.password = password;
         this.name = name;
         this.role = role;
     }

--- a/src/main/java/com/hamster/gro_up/repository/UserRepository.java
+++ b/src/main/java/com/hamster/gro_up/repository/UserRepository.java
@@ -6,5 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.dto.request.SigninRequest;
+import com.hamster.gro_up.dto.request.SignupRequest;
+import com.hamster.gro_up.dto.response.TokenResponse;
+import com.hamster.gro_up.entity.Role;
+import com.hamster.gro_up.entity.User;
+import com.hamster.gro_up.repository.UserRepository;
+import com.hamster.gro_up.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public TokenResponse signup(SignupRequest signupRequest) {
+
+        if (userRepository.existsByEmail(signupRequest.getEmail())) {
+            throw new RuntimeException("이미 존재하는 이메일입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
+
+        User user = User.builder()
+                .email(signupRequest.getEmail())
+                .name(signupRequest.getName())
+                .password(encodedPassword)
+                .role(Role.ROLE_USER)
+                .build();
+
+        User savedUser = userRepository.save(user);
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getName(), savedUser.getRole());
+
+        return new TokenResponse(bearerToken);
+    }
+
+    public TokenResponse signin(SigninRequest signinRequest) {
+        User user = userRepository.findByEmail(signinRequest.getEmail()).orElseThrow(
+                () -> new RuntimeException("가입되지 않은 유저입니다."));
+
+        // TODO: 로그인 시 이메일과 비밀번호가 일치하지 않을 경우 401을 반환해야합니다.
+        if (!passwordEncoder.matches(signinRequest.getPassword(), user.getPassword())) {
+            throw new RuntimeException("잘못된 비밀번호입니다.");
+        }
+
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getName(), user.getRole());
+
+        return new TokenResponse(bearerToken);
+    }
+}

--- a/src/test/java/com/hamster/gro_up/GroUpApplicationTests.java
+++ b/src/test/java/com/hamster/gro_up/GroUpApplicationTests.java
@@ -1,15 +1,10 @@
 package com.hamster.gro_up;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class GroUpApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
 
 }

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -1,0 +1,86 @@
+package com.hamster.gro_up.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hamster.gro_up.config.CustomOAuth2SuccessHandler;
+import com.hamster.gro_up.config.SecurityConfig;
+import com.hamster.gro_up.dto.request.SigninRequest;
+import com.hamster.gro_up.dto.request.SignupRequest;
+import com.hamster.gro_up.dto.response.TokenResponse;
+import com.hamster.gro_up.service.AuthService;
+import com.hamster.gro_up.service.CustomOAuth2UserService;
+import com.hamster.gro_up.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = { AuthController.class })
+@Import({SecurityConfig.class, JwtUtil.class})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockBean
+    private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
+    @Test
+    @DisplayName("회원가입에 성공하면 토큰을 반환한다")
+    void signup_success() throws Exception {
+        // given
+        SignupRequest signupRequest = new SignupRequest("test@test.com", "test", "password");
+        TokenResponse token = new TokenResponse("token");
+        given(authService.signup(any(SignupRequest.class))).willReturn(token);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signupRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data.token").value(token.getToken()));
+
+    }
+
+    @Test
+    @DisplayName("로그인에 성공하면 토큰을 반환한다")
+    void signin_success() throws Exception {
+        // given
+        SigninRequest signinRequest = new SigninRequest("test@test.com", "password");
+        TokenResponse token = new TokenResponse("token");
+        given(authService.signin(any(SigninRequest.class))).willReturn(token);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/siginin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(signinRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data.token").value(token.getToken()));
+    }
+}

--- a/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
@@ -1,0 +1,93 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.dto.request.SigninRequest;
+import com.hamster.gro_up.dto.request.SignupRequest;
+import com.hamster.gro_up.dto.response.TokenResponse;
+import com.hamster.gro_up.entity.Role;
+import com.hamster.gro_up.entity.User;
+import com.hamster.gro_up.repository.UserRepository;
+import com.hamster.gro_up.util.JwtUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private SignupRequest signupRequest;
+    private SigninRequest signinRequest;
+    private User user;
+
+    @BeforeEach
+    void setup() {
+        signupRequest = new SignupRequest("test@gmail.com", "test", "password");
+        signinRequest = new SigninRequest("test@email.com", "testpw");
+
+        user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .password("password")
+                .name("ham")
+                .password("encoded_password")
+                .role(Role.ROLE_USER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입에 성공하면 토큰을 반환한다.")
+    void signup_success() {
+        // given
+        given(userRepository.existsByEmail(signupRequest.getEmail())).willReturn(false);
+        given(passwordEncoder.encode(signupRequest.getPassword())).willReturn("encoded_password");
+        given(userRepository.save(any(User.class))).willReturn(user);
+        given(jwtUtil.createToken(anyLong(), anyString(), anyString(), any(Role.class))).willReturn("token");
+
+        // when
+        TokenResponse response = authService.signup(signupRequest);
+
+        // then
+        assertThat(response.getToken()).isEqualTo("token");
+    }
+
+    @Test
+    @DisplayName("로그인에 성공하면 토큰을 반환한다")
+    void signin_success() {
+        // given
+        given(userRepository.findByEmail(signinRequest.getEmail())).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(signinRequest.getPassword(), user.getPassword())).willReturn(true);
+        given(jwtUtil.createToken(anyLong(), anyString(), anyString(), any(Role.class))).willReturn("token");
+
+        // when
+        TokenResponse response = authService.signin(signinRequest);
+
+        // then
+        assertThat(response.getToken()).isEqualTo("token");
+    }
+
+}

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -81,7 +81,7 @@ class CompanyServiceTest {
     @DisplayName("기업 수정에 성공한다")
     void updateCompany_success() {
         // given
-        long companyId = 1L;
+        long companyId = 10L;
         CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "www.new.com", "busan");
         given(companyRepository.findById(10L)).willReturn(Optional.of(company));
 


### PR DESCRIPTION
## 작업 내용
기존 OAuth2 에 더해서 일반 로그인 및 회원가입을 구현했습니다.

## 작업 상세
* 일반 로그인 및 회원가입 Controller, Service 구현
* 성공 시의 테스트 코드 작성
  * 추후 예외 처리를 구현한 후에 실패 시의 테스트 코드를 작성할 예정입니다.

## 관련 이슈
This closes #14 