### PR TITLE
feat: 공통 예외 처리 구현

### DIFF
--- a/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
+++ b/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
@@ -1,0 +1,96 @@
+package com.hamster.gro_up.advise;
+
+import com.hamster.gro_up.dto.ApiResponse;
+import com.hamster.gro_up.exception.BadRequestException;
+import com.hamster.gro_up.exception.ForbiddenException;
+import com.hamster.gro_up.exception.NotFoundException;
+import com.hamster.gro_up.exception.UnauthorizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ApiResponse<Object> handleBadRequestException(BadRequestException e) {
+        log.error(e.getMessage());
+        
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage(),
+                null
+        );
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ApiResponse<Object> handleAuthenticationException(UnauthorizedException e) {
+        log.error(e.getMessage());
+        
+        return ApiResponse.of(
+                HttpStatus.UNAUTHORIZED,
+                e.getMessage(),
+                null
+        );
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ApiResponse<Object> handleForbiddenException(ForbiddenException e) {
+        log.error(e.getMessage());
+
+        return ApiResponse.of(
+                HttpStatus.FORBIDDEN,
+                e.getMessage(),
+                null
+        );
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ApiResponse<Object> handleNotFoundException(NotFoundException e) {
+        log.error(e.getMessage());
+
+        return ApiResponse.of(
+                HttpStatus.NOT_FOUND,
+                e.getMessage(),
+                null
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<Object> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+
+        return ApiResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "서버 오류가 발생했습니다.",
+                null
+        );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Object> handleValidationException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+
+        StringBuilder sb = new StringBuilder();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            sb.append("[");
+            sb.append(fieldError.getField());
+            sb.append("](은)는 ");
+            sb.append(fieldError.getDefaultMessage());
+            sb.append(" 입력된 값: [");
+            sb.append(fieldError.getRejectedValue());
+            sb.append("]");
+        }
+
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                sb.toString(),
+                null
+        );
+    }
+}

--- a/src/main/java/com/hamster/gro_up/exception/BadRequestException.java
+++ b/src/main/java/com/hamster/gro_up/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.hamster.gro_up.exception;
+
+
+public class BadRequestException extends RuntimeException {
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    public BadRequestException() {super(MESSAGE);}
+
+    public BadRequestException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/ForbiddenException.java
+++ b/src/main/java/com/hamster/gro_up/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.hamster.gro_up.exception;
+
+public class ForbiddenException extends RuntimeException{
+    private static final String MESSAGE = "접근이 금지되었습니다.";
+
+    public ForbiddenException() {super(MESSAGE);}
+
+    public ForbiddenException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/NotFoundException.java
+++ b/src/main/java/com/hamster/gro_up/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.hamster.gro_up.exception;
+
+public class NotFoundException extends RuntimeException {
+    private static final String MESSAGE = "리소스를 찾을 수 없습니다.";
+
+    public NotFoundException() {super(MESSAGE);}
+
+    public NotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/UnauthorizedException.java
+++ b/src/main/java/com/hamster/gro_up/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.hamster.gro_up.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    private static final String MESSAGE = "인증이 필요합니다.";
+
+    public UnauthorizedException() {super(MESSAGE);}
+
+    public UnauthorizedException(String message) {super(message);}
+}


### PR DESCRIPTION
## 작업 내용
`@RestControllerAdvice` 를 이용하여 공통 예외 처리를 구현했습니다.

## 작업 상세
`/exception` 내의 공통 예외 클래스를 상속받아 커스텀 예외를 정의하면 예외 발생 시 일관된 에러 응답이 반환됩니다.

* 400 Bad Request : BadRequestException
* 401 Unauthorized : UnauthorizedException
* 403 Forbidden : ForbiddenException
* 404 Not Found : NotFoundException

## 관련 이슈
This closes #3 