### PR TITLE
feat: `ResponseEntity`  를 사용하여 API 응답 개선 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
+++ b/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.hamster.gro_up.exception.NotFoundException;
 import com.hamster.gro_up.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,63 +19,57 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
-    public ApiResponse<Object> handleBadRequestException(BadRequestException e) {
+    public ResponseEntity<ApiResponse<Object>> handleBadRequestException(BadRequestException e) {
         log.error(e.getMessage());
-        
-        return ApiResponse.of(
-                HttpStatus.BAD_REQUEST,
-                e.getMessage(),
-                null
-        );
+
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ApiResponse<Object> handleAuthenticationException(UnauthorizedException e) {
+    public ResponseEntity<ApiResponse<Object>> handleAuthenticationException(UnauthorizedException e) {
         log.error(e.getMessage());
-        
-        return ApiResponse.of(
-                HttpStatus.UNAUTHORIZED,
-                e.getMessage(),
-                null
-        );
+
+        HttpStatus status = HttpStatus.UNAUTHORIZED;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ApiResponse<Object> handleForbiddenException(ForbiddenException e) {
+    public ResponseEntity<ApiResponse<Object>> handleForbiddenException(ForbiddenException e) {
         log.error(e.getMessage());
 
-        return ApiResponse.of(
-                HttpStatus.FORBIDDEN,
-                e.getMessage(),
-                null
-        );
+        HttpStatus status = HttpStatus.FORBIDDEN;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ApiResponse<Object> handleNotFoundException(NotFoundException e) {
+    public ResponseEntity<ApiResponse<Object>> handleNotFoundException(NotFoundException e) {
         log.error(e.getMessage());
 
-        return ApiResponse.of(
-                HttpStatus.NOT_FOUND,
-                e.getMessage(),
-                null
-        );
+        HttpStatus status = HttpStatus.NOT_FOUND;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }
 
     @ExceptionHandler(Exception.class)
-    public ApiResponse<Object> handleException(Exception e) {
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
         log.error("Unhandled exception", e);
 
-        return ApiResponse.of(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "서버 오류가 발생했습니다.",
-                null
-        );
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ApiResponse<Object> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<Object>> handleValidationException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage());
+
         BindingResult bindingResult = e.getBindingResult();
+
+        HttpStatus status = HttpStatus.BAD_REQUEST;
 
         StringBuilder sb = new StringBuilder();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
@@ -87,10 +82,6 @@ public class GlobalExceptionHandler {
             sb.append("]");
         }
 
-        return ApiResponse.of(
-                HttpStatus.BAD_REQUEST,
-                sb.toString(),
-                null
-        );
+        return ResponseEntity.status(status).body(ApiResponse.of(status, sb.toString(), null));
     }
 }

--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,14 +20,14 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ApiResponse<TokenResponse> signup(@RequestBody SignupRequest signupRequest) {
+    public ResponseEntity<ApiResponse<TokenResponse>> signup(@RequestBody SignupRequest signupRequest) {
         TokenResponse response = authService.signup(signupRequest);
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @PostMapping("/siginin")
-    public ApiResponse<TokenResponse> signin(@RequestBody SigninRequest signinRequest) {
+    public ResponseEntity<ApiResponse<TokenResponse>> signin(@RequestBody SigninRequest signinRequest) {
         TokenResponse response = authService.signin(signinRequest);
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/hamster/gro_up/controller/CompanyController.java
+++ b/src/main/java/com/hamster/gro_up/controller/CompanyController.java
@@ -4,10 +4,12 @@ import com.hamster.gro_up.dto.ApiResponse;
 import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
+import com.hamster.gro_up.dto.response.CompanyListResponse;
 import com.hamster.gro_up.dto.response.CompanyResponse;
 import com.hamster.gro_up.service.CompanyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,29 +21,29 @@ public class CompanyController {
     private final CompanyService companyService;
 
     @GetMapping("/{companyId}")
-    public ApiResponse<CompanyResponse> findCompany(@AuthenticationPrincipal AuthUser authUser, @PathVariable long companyId) {
+    public ResponseEntity<ApiResponse<CompanyResponse>> findCompany(@AuthenticationPrincipal AuthUser authUser, @PathVariable long companyId) {
         CompanyResponse response = companyService.findCompany(authUser, companyId);
-        return ApiResponse.ok(response);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @PostMapping
-    public ApiResponse<CompanyResponse> createCompany(@AuthenticationPrincipal AuthUser authUser, @RequestBody CompanyCreateRequest companyCreateRequest) {
+    public ResponseEntity<ApiResponse<CompanyResponse>> createCompany(@AuthenticationPrincipal AuthUser authUser, @RequestBody CompanyCreateRequest companyCreateRequest) {
         CompanyResponse response = companyService.createCompany(authUser, companyCreateRequest);
-        return ApiResponse.of(HttpStatus.CREATED, response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(HttpStatus.CREATED, response));
     }
 
     @PutMapping("/{companyId}")
-    public ApiResponse<Void> updateCompany(@AuthenticationPrincipal AuthUser authUser,
-                                         @PathVariable long companyId,
-                                         @RequestBody CompanyUpdateRequest companyUpdateRequest) {
+    public ResponseEntity<ApiResponse<Void>> updateCompany(@AuthenticationPrincipal AuthUser authUser,
+                                           @PathVariable long companyId,
+                                           @RequestBody CompanyUpdateRequest companyUpdateRequest) {
         companyService.updateCompany(authUser, companyId, companyUpdateRequest);
-        return ApiResponse.ok(null);
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @DeleteMapping("/{companyId}")
-    public ApiResponse<Void> deleteCompany(@AuthenticationPrincipal AuthUser authUser,
-                                              @PathVariable long companyId) {
+    public ResponseEntity<ApiResponse<Void>> deleteCompany(@AuthenticationPrincipal AuthUser authUser,
+                                           @PathVariable long companyId) {
         companyService.deleteCompany(authUser, companyId);
-        return ApiResponse.ok(null);
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }


### PR DESCRIPTION
## 작업 내용
기존에 컨트롤러/예외 핸들러에서 ApiResponse만 반환하던 방식을
ResponseEntity<ApiResponse> 로 변경했습니다.

## 작업 상세
* HTTP status 코드와 응답 바디의 code/status가 항상  일치하도록 개선
* 컨트롤러에서 예외가 발생하는 경우의 테스트 코드 작성

## 관련 이슈
* This closes #19 