### PR TITLE
feat: `Flyway` 기반 DB 마이그레이션 도구 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+	// flyway
+	implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hamster/gro_up/controller/CompanyController.java
+++ b/src/main/java/com/hamster/gro_up/controller/CompanyController.java
@@ -54,7 +54,7 @@ public class CompanyController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
-    @Operation(summary = "기엽 삭제")
+    @Operation(summary = "기업 삭제")
     @DeleteMapping("/{companyId}")
     public ResponseEntity<ApiResponse<Void>> deleteCompany(@AuthenticationPrincipal AuthUser authUser,
                                                            @PathVariable long companyId) {

--- a/src/main/java/com/hamster/gro_up/entity/Company.java
+++ b/src/main/java/com/hamster/gro_up/entity/Company.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Company extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String companyName;

--- a/src/main/java/com/hamster/gro_up/entity/Favorite.java
+++ b/src/main/java/com/hamster/gro_up/entity/Favorite.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Favorite extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(name = "company_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT), updatable = false, nullable = false)

--- a/src/main/java/com/hamster/gro_up/entity/Retrospect.java
+++ b/src/main/java/com/hamster/gro_up/entity/Retrospect.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Retrospect extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String memo;

--- a/src/main/java/com/hamster/gro_up/entity/Schedule.java
+++ b/src/main/java/com/hamster/gro_up/entity/Schedule.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Entity
 public class Schedule extends BaseEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/hamster/gro_up/entity/User.java
+++ b/src/main/java/com/hamster/gro_up/entity/User.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class User {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String email;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
         format_sql: true
         show_sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
   security:
     oauth2:
       client:
@@ -25,6 +25,11 @@ spring:
             scope:
               - profile
               - email
+  flyway:
+    enabled: true
+    url: ${LOCAL_DB_URL}
+    user: root # MySQL 사용자 이름
+    password: ${LOCAL_DB_PASSWORD}
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}  # JWT 비밀 키

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,68 @@
+-- user 테이블
+CREATE TABLE user (
+                      id BIGINT NOT NULL AUTO_INCREMENT,
+                      email VARCHAR(255),
+                      name VARCHAR(255),
+                      password VARCHAR(255),
+                      role ENUM ('ROLE_ADMIN', 'ROLE_USER'),
+                      created_at DATETIME(6),
+                      modified_at DATETIME(6),
+                      PRIMARY KEY (id),
+                      UNIQUE (email)
+);
+
+-- company 테이블
+CREATE TABLE company (
+                         id BIGINT NOT NULL AUTO_INCREMENT,
+                         user_id BIGINT NOT NULL,
+                         company_name VARCHAR(255),
+                         location VARCHAR(255),
+                         position VARCHAR(255),
+                         url VARCHAR(255),
+                         created_at DATETIME(6),
+                         modified_at DATETIME(6),
+                         PRIMARY KEY (id),
+                         FOREIGN KEY (user_id) REFERENCES user(id)
+);
+
+-- schedule 테이블
+CREATE TABLE schedule (
+                          id BIGINT NOT NULL AUTO_INCREMENT,
+                          user_id BIGINT NOT NULL,
+                          company_id BIGINT NOT NULL,
+                          position VARCHAR(255),
+                          memo VARCHAR(255),
+                          due_date DATETIME(6),
+                          step ENUM ('ASSIGNMENT_TEST','CODING_TEST','DOCUMENT','FAIL','FINAL_PASS','FIRST_INTERVIEW','SECOND_INTERVIEW','THIRD_INTERVIEW'),
+                          created_at DATETIME(6),
+                          modified_at DATETIME(6),
+                          PRIMARY KEY (id),
+                          FOREIGN KEY (user_id) REFERENCES user(id),
+                          FOREIGN KEY (company_id) REFERENCES company(id)
+);
+
+-- favorite 테이블
+CREATE TABLE favorite (
+                          id BIGINT NOT NULL AUTO_INCREMENT,
+                          user_id BIGINT NOT NULL,
+                          company_id BIGINT NOT NULL,
+                          created_at DATETIME(6),
+                          modified_at DATETIME(6),
+                          PRIMARY KEY (id),
+                          FOREIGN KEY (user_id) REFERENCES user(id),
+                          FOREIGN KEY (company_id) REFERENCES company(id)
+);
+
+-- retrospect 테이블
+CREATE TABLE retrospect (
+                            id BIGINT NOT NULL AUTO_INCREMENT,
+                            user_id BIGINT NOT NULL,
+                            schedule_id BIGINT NOT NULL,
+                            memo VARCHAR(255),
+                            created_at DATETIME(6),
+                            modified_at DATETIME(6),
+                            PRIMARY KEY (id),
+                            FOREIGN KEY (user_id) REFERENCES user(id),
+                            FOREIGN KEY (schedule_id) REFERENCES schedule(id),
+                            UNIQUE (schedule_id)
+);


### PR DESCRIPTION
## 작업 내용
`Flyway` 를 도입하여 데이터베이스 스키마 버전 관리를 시작합니다.

## 작업 상세
* 앞으로 모든 DB 구조 변경은 `src/main/resourecs/db/migraion 폴더에 버전별 마이그레이션 파일 추가로 관리합니다.
* 마이그레이션 파일명은 `Flyway` 공식 규칙을 따릅니다.
  * ex) V1__init.sql, V2__add_table.sql, V3__add_user_index.sql

## 관련 이슈
This closes #29 