### PR TITLE
feat: 인증, 인가 예외처리 커스텀 적용

### DIFF
--- a/src/main/java/com/hamster/gro_up/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/hamster/gro_up/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.hamster.gro_up.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Access Denied\"}");
+    }
+}

--- a/src/main/java/com/hamster/gro_up/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hamster/gro_up/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.hamster.gro_up.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+        response.setContentType("application/json");
+        response.getWriter().write("{\"error\": \"Unauthorized\"}");
+    }
+}

--- a/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
+++ b/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
@@ -25,6 +25,8 @@ public class SecurityConfig {
     private final JwtSecurityFilter jwtSecurityFilter;
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {
@@ -35,7 +37,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**", "/swagger-ui/**", "swagger-ui.html", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/oauth2/**", "/login/oauth2/**", "/api/auth/**", "/swagger-ui/**", "swagger-ui.html", "/v3/api-docs/**")
+                        .permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
@@ -52,7 +55,11 @@ public class SecurityConfig {
                 .anonymous(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)).build();
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
## 작업 내용
인증 및 인가 실패 시 Spring Security 기본 동작(로그인 페이지 리다이렉트) 대신 `401 Unauthorized` 에러 혹은 `403 Access Denied` 에러와 JSON 메시지를 반환하도록 커스텀하여 구현했습니다.

## 작업 상세
* 인증 예외 처리 커스텀
  * `CustomAuthenticationEntryPoint`
* 인가 예외 처리 커스텀
  * `CustomAccessDeniedHandler`

## 관련 이슈
This closes #31