### PR TITLE
fix: `@MockBean` 추가로 Security 관련 테스트 실패 해결

### DIFF
--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -1,6 +1,8 @@
 package com.hamster.gro_up.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hamster.gro_up.config.CustomAccessDeniedHandler;
+import com.hamster.gro_up.config.CustomAuthenticationEntryPoint;
 import com.hamster.gro_up.config.CustomOAuth2SuccessHandler;
 import com.hamster.gro_up.config.SecurityConfig;
 import com.hamster.gro_up.dto.request.SigninRequest;
@@ -44,6 +46,12 @@ class AuthControllerTest {
 
     @MockBean
     private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @MockBean
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Test
     @DisplayName("회원가입에 성공하면 토큰을 반환한다")

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -1,9 +1,7 @@
 package com.hamster.gro_up.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hamster.gro_up.config.CustomOAuth2SuccessHandler;
-import com.hamster.gro_up.config.SecurityConfig;
-import com.hamster.gro_up.config.WithMockAuthUser;
+import com.hamster.gro_up.config.*;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
 import com.hamster.gro_up.dto.response.CompanyListResponse;
@@ -50,6 +48,12 @@ class CompanyControllerTest {
 
     @MockBean
     private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @MockBean
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Test
     @DisplayName("기업 조회에 성공한다")


### PR DESCRIPTION
## 작업 내용
인증, 인가 예외 처리 관련 커스텀 빈들을 Mock 객체로 등록하여 테스트가 정상적으로 동작하도록 수정했습니다.

## 관련 이슈
This closes #36 