### PR TITLE
fix: gradlew 실행 권한 부여

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: application.yml 파일 만들기
         run: echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/application-prod.yml
 
+      - name: gradlew 실행 권한 부여
+        run: chmod +x ./gradlew
+
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build
 


### PR DESCRIPTION
## 작업 내용
권한 문제로 gradlew 실행이 되지 않았기에 권한을 부여하는 step 을 추가했습니다.

## 관련 이슈
This closes #37 