### PR TITLE
feat: 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
 	// flyway
 	implementation 'org.flywaydb:flyway-mysql'
+
+	// mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
+++ b/src/main/java/com/hamster/gro_up/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000")); // 프론트엔드 주소
+        config.setAllowedOrigins(List.of("http://localhost:5173")); // 프론트엔드 주소
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("*"));

--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -5,15 +5,13 @@ import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.service.AuthService;
+import com.hamster.gro_up.service.EmailVerificationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "인증 및 인가", description = "인증 및 인가 관련 API")
 @RequiredArgsConstructor
@@ -22,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailVerificationService emailVerificationService;
 
     @Operation(summary = "일반 회원가입")
     @PostMapping("/signup")
@@ -35,5 +34,19 @@ public class AuthController {
     public ResponseEntity<ApiResponse<TokenResponse>> signin(@Valid @RequestBody SigninRequest signinRequest) {
         TokenResponse response = authService.signin(signinRequest);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "이메일 인증 요청")
+    @PostMapping("/email/verify-request")
+    public ResponseEntity<ApiResponse<Void>> sendVerificationCode(@RequestParam String email) {
+        emailVerificationService.sendVerificationCode(email);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "이메일 인증 코드 검증")
+    @PostMapping("/email/verify-check")
+    public ResponseEntity<ApiResponse<Void>> checkVerificationCode(@RequestParam String email, @RequestParam String code) {
+        emailVerificationService.verifyCode(email, code);
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/hamster/gro_up/entity/EmailVerificationToken.java
+++ b/src/main/java/com/hamster/gro_up/entity/EmailVerificationToken.java
@@ -1,0 +1,33 @@
+package com.hamster.gro_up.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class EmailVerificationToken extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String token;
+
+    private String email;
+
+    private LocalDateTime expiryDate;
+
+    @Setter
+    private boolean used = false;
+
+    @Builder
+    public EmailVerificationToken(String email, LocalDateTime expiryDate, Long id, String token, boolean used) {
+        this.email = email;
+        this.expiryDate = expiryDate;
+        this.id = id;
+        this.token = token;
+        this.used = used;
+    }
+}

--- a/src/main/java/com/hamster/gro_up/entity/User.java
+++ b/src/main/java/com/hamster/gro_up/entity/User.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-public class User {
+public class User extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/hamster/gro_up/exception/auth/EmailNotVerifiedException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/EmailNotVerifiedException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.ForbiddenException;
+
+public class EmailNotVerifiedException extends ForbiddenException {
+    private static final String MESSAGE = "인증되지 않은 이메일입니다.";
+
+    public EmailNotVerifiedException() {super(MESSAGE);}
+
+    public EmailNotVerifiedException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/auth/InvalidEmailVerificationTokenException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/InvalidEmailVerificationTokenException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.BadRequestException;
+
+public class InvalidEmailVerificationTokenException extends BadRequestException {
+    private static final String MESSAGE = "인증 코드가 유효하지 않습니다.";
+
+    public InvalidEmailVerificationTokenException() {super(MESSAGE);}
+
+    public InvalidEmailVerificationTokenException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/repository/EmailVerificationTokenRepository.java
+++ b/src/main/java/com/hamster/gro_up/repository/EmailVerificationTokenRepository.java
@@ -1,0 +1,12 @@
+package com.hamster.gro_up.repository;
+
+import com.hamster.gro_up.entity.EmailVerificationToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailVerificationTokenRepository extends JpaRepository<EmailVerificationToken, Long> {
+    Optional<EmailVerificationToken> findByEmailAndTokenAndUsedFalse(String email, String token);
+
+    boolean existsByEmailAndUsedTrue(String email);
+}

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -5,6 +5,7 @@ import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
 import com.hamster.gro_up.entity.User;
+import com.hamster.gro_up.exception.auth.EmailNotVerifiedException;
 import com.hamster.gro_up.exception.auth.InvalidCredentialsException;
 import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.exception.user.UserNotFoundException;
@@ -22,6 +23,7 @@ public class AuthService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final EmailVerificationService emailVerificationService;
     private final JwtUtil jwtUtil;
 
     @Transactional
@@ -29,6 +31,10 @@ public class AuthService {
 
         if (userRepository.existsByEmail(signupRequest.getEmail())) {
             throw new DuplicateUserException();
+        }
+
+        if(!emailVerificationService.isEmailVerified(signupRequest.getEmail())) {
+            throw new EmailNotVerifiedException();
         }
 
         String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());

--- a/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
+++ b/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
@@ -1,0 +1,73 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.entity.EmailVerificationToken;
+import com.hamster.gro_up.exception.auth.InvalidEmailVerificationTokenException;
+import com.hamster.gro_up.exception.user.DuplicateUserException;
+import com.hamster.gro_up.repository.EmailVerificationTokenRepository;
+import com.hamster.gro_up.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class EmailVerificationService {
+
+    private final EmailVerificationTokenRepository tokenRepository;
+    private final UserRepository userRepository;
+    private final JavaMailSender mailSender;
+
+    @Transactional
+    public void sendVerificationCode(String email) {
+
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateUserException("이미 가입된 이메일입니다.");
+        }
+
+        // 6자리 숫자 코드 생성
+        String code = String.format("%06d", new Random().nextInt(999999));
+
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .email(email)
+                .token(code)
+                .expiryDate(LocalDateTime.now().plusMinutes(10))
+                .build();
+
+        tokenRepository.save(token);
+
+        // 이메일 발송
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject("이메일 인증 코드");
+        message.setText("인증 코드: " + code);
+        mailSender.send(message);
+    }
+
+    @Transactional
+    public void verifyCode(String email, String code) {
+        Optional<EmailVerificationToken> optionalToken = tokenRepository.findByEmailAndTokenAndUsedFalse(email, code);
+
+        if (optionalToken.isPresent()) {
+            EmailVerificationToken token = optionalToken.get();
+            if (token.getExpiryDate().isAfter(LocalDateTime.now())) {
+                token.setUsed(true);
+                return;
+            }
+        }
+
+        throw new InvalidEmailVerificationTokenException();
+    }
+
+    // 인증 완료 여부 확인
+    public boolean isEmailVerified(String email) {
+        // 인증 성공한 토큰이 있는지 확인
+        return tokenRepository.existsByEmailAndUsedTrue(email);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,15 @@ spring:
             scope:
               - profile
               - email
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+      mail.smtp.timeout: 5000
   flyway:
     enabled: true
     url: ${LOCAL_DB_URL}

--- a/src/main/resources/db/migration/V2__create_email_verification_token.sql
+++ b/src/main/resources/db/migration/V2__create_email_verification_token.sql
@@ -1,0 +1,12 @@
+-- EmailVerificationToken 테이블
+CREATE TABLE email_verification_token (
+                                          id BIGINT NOT NULL AUTO_INCREMENT,
+                                          token VARCHAR(255) NOT NULL,
+                                          email VARCHAR(255) NOT NULL,
+                                          expiry_date DATETIME(6) NOT NULL,
+                                          used BOOLEAN NOT NULL DEFAULT FALSE,
+                                          created_at DATETIME(6),
+                                          modified_at DATETIME(6),
+                                          PRIMARY KEY (id),
+                                          INDEX idx_email (email)
+);

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -8,8 +8,11 @@ import com.hamster.gro_up.config.SecurityConfig;
 import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
+import com.hamster.gro_up.exception.auth.InvalidEmailVerificationTokenException;
+import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.service.AuthService;
 import com.hamster.gro_up.service.CustomOAuth2UserService;
+import com.hamster.gro_up.service.EmailVerificationService;
 import com.hamster.gro_up.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +26,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -40,6 +44,9 @@ class AuthControllerTest {
 
     @MockBean
     private AuthService authService;
+
+    @MockBean
+    private EmailVerificationService emailVerificationService;
 
     @MockBean
     private CustomOAuth2UserService customOAuth2UserService;
@@ -111,5 +118,75 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.message").isNotEmpty())
                 .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 요청에 성공한다")
+    void sendVerificationCode_success() throws Exception {
+        // given
+        String email = "test@example.com";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/email/verify-request")
+                        .param("email", email)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 요청 시 이미 가입된 이메일이면 예외가 발생한다")
+    void sendVerificationCode_fail_duplicate() throws Exception {
+        // given
+        String email = "test@example.com";
+        doThrow(new DuplicateUserException("이미 가입된 이메일입니다."))
+                .when(emailVerificationService).sendVerificationCode(email);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/email/verify-request")
+                        .param("email", email)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증에 성공한다")
+    void checkVerificationCode_success() throws Exception {
+        // given
+        String email = "test@example.com";
+        String code = "123456";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/email/verify-check")
+                        .param("email", email)
+                        .param("code", code)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증에 실패하면 예외가 발생한다")
+    void checkVerificationCode_fail_invalid() throws Exception {
+        // given
+        String email = "test@example.com";
+        String code = "wrongcode";
+        doThrow(new InvalidEmailVerificationTokenException())
+                .when(emailVerificationService).verifyCode(email, code);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/email/verify-check")
+                        .param("email", email)
+                        .param("code", code)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("인증 코드가 유효하지 않습니다."));
     }
 }

--- a/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
@@ -10,7 +10,6 @@ import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.exception.user.UserNotFoundException;
 import com.hamster.gro_up.repository.UserRepository;
 import com.hamster.gro_up.util.JwtUtil;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.any;
@@ -34,6 +33,9 @@ class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private EmailVerificationService emailVerificationService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -71,6 +73,7 @@ class AuthServiceTest {
         given(passwordEncoder.encode(signupRequest.getPassword())).willReturn("encoded_password");
         given(userRepository.save(any(User.class))).willReturn(user);
         given(jwtUtil.createToken(anyLong(), anyString(), anyString(), any(Role.class))).willReturn("token");
+        given(emailVerificationService.isEmailVerified(signupRequest.getEmail())).willReturn(true);
 
         // when
         TokenResponse response = authService.signup(signupRequest);

--- a/src/test/java/com/hamster/gro_up/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/EmailVerificationServiceTest.java
@@ -1,0 +1,159 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.entity.EmailVerificationToken;
+import com.hamster.gro_up.exception.auth.InvalidEmailVerificationTokenException;
+import com.hamster.gro_up.exception.user.DuplicateUserException;
+import com.hamster.gro_up.repository.EmailVerificationTokenRepository;
+import com.hamster.gro_up.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceTest {
+
+    @Mock
+    private EmailVerificationTokenRepository tokenRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @InjectMocks
+    private EmailVerificationService emailVerificationService;
+
+    @Captor
+    private ArgumentCaptor<SimpleMailMessage> mailCaptor;
+
+    @Test
+    @DisplayName("이메일 인증 코드 발송에 성공한다")
+    void sendVerificationCode_success() {
+        // given
+        String email = "test@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(false);
+
+        // when
+        emailVerificationService.sendVerificationCode(email);
+
+        // then
+        verify(tokenRepository).save(any(EmailVerificationToken.class));
+        verify(mailSender).send(mailCaptor.capture());
+        SimpleMailMessage message = mailCaptor.getValue();
+        assertThat(message.getTo()).contains(email);
+        assertThat(message.getSubject()).isEqualTo("이메일 인증 코드");
+        assertThat(message.getText()).contains("인증 코드:");
+    }
+
+    @Test
+    @DisplayName("이미 가입된 이메일이면 예외가 발생한다")
+    void sendVerificationCode_fail_duplicate() {
+        // given
+        String email = "test@example.com";
+        given(userRepository.existsByEmail(email)).willReturn(true);
+
+        // when & then
+        assertThrows(DuplicateUserException.class, () -> emailVerificationService.sendVerificationCode(email));
+        verify(tokenRepository, never()).save(any());
+        verify(mailSender, never()).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    @DisplayName("인증 코드 검증에 성공하면 토큰이 사용 처리된다")
+    void verifyCode_success() {
+        // given
+        String email = "test@example.com";
+        String code = "123456";
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .email(email)
+                .token(code)
+                .expiryDate(LocalDateTime.now().plusMinutes(10))
+                .used(false)
+                .build();
+
+        given(tokenRepository.findByEmailAndTokenAndUsedFalse(email, code)).willReturn(Optional.of(token));
+
+        // when
+        emailVerificationService.verifyCode(email, code);
+
+        // then
+        assertThat(token.isUsed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 인증 코드는 예외가 발생한다")
+    void verifyCode_fail_expired() {
+        // given
+        String email = "test@example.com";
+        String code = "123456";
+        EmailVerificationToken token = EmailVerificationToken.builder()
+                .email(email)
+                .token(code)
+                .expiryDate(LocalDateTime.now().minusMinutes(1)) // 만료
+                .used(false)
+                .build();
+
+        given(tokenRepository.findByEmailAndTokenAndUsedFalse(email, code)).willReturn(Optional.of(token));
+
+        // when & then
+        assertThrows(InvalidEmailVerificationTokenException.class, () -> emailVerificationService.verifyCode(email, code));
+    }
+
+    @Test
+    @DisplayName("잘못된 인증 코드는 예외가 발생한다")
+    void verifyCode_fail_invalid() {
+        // given
+        String email = "test@example.com";
+        String code = "wrongcode";
+        given(tokenRepository.findByEmailAndTokenAndUsedFalse(email, code)).willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(InvalidEmailVerificationTokenException.class, () -> emailVerificationService.verifyCode(email, code));
+    }
+
+    @Test
+    @DisplayName("이메일 인증이 완료된 경우 true 를 반환한다")
+    void isEmailVerified_true() {
+        // given
+        String email = "test@example.com";
+        given(tokenRepository.existsByEmailAndUsedTrue(email)).willReturn(Boolean.TRUE);
+
+        // when
+        boolean result = emailVerificationService.isEmailVerified(email);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("이메일 인증이 완료되지 않은 경우 false 를 반환한다")
+    void isEmailVerified_false() {
+        // given
+        String email = "test@example.com";
+        given(tokenRepository.existsByEmailAndUsedTrue(email)).willReturn(Boolean.FALSE);
+
+        // when
+        boolean result = emailVerificationService.isEmailVerified(email);
+
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## 작업 내용
회원가입 시 이메일 인증 기능을 구현했습니다.

## 작업 상세
* 이메일 인증 코드 테이블 생성 sql 작성
* 인증 코드 발송 및 검증 구현
* 이메일 인증 관련 테스트 코드 작성
* 회원 가입 로직
  * 1. 이메일 인증 요청
    * 이메일 중복 검사 후에 요청
  * 2. 이메일 인증 코드 검증
  * 3. 회원 가입 진행

## 관련 이슈
This closes #42 