### PR TITLE
feat: 일정 기본 CRUD 구현

### DIFF
--- a/src/main/java/com/hamster/gro_up/controller/CompanyController.java
+++ b/src/main/java/com/hamster/gro_up/controller/CompanyController.java
@@ -33,8 +33,8 @@ public class CompanyController {
 
     @Operation(summary = "해당 사용자의 모든 기업 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<CompanyListResponse>> findAllCompany(@AuthenticationPrincipal AuthUser authUser) {
-        CompanyListResponse response = companyService.findAllCompany(authUser);
+    public ResponseEntity<ApiResponse<CompanyListResponse>> findAllCompanies(@AuthenticationPrincipal AuthUser authUser) {
+        CompanyListResponse response = companyService.findAllCompanies(authUser);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
+++ b/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
@@ -1,0 +1,62 @@
+package com.hamster.gro_up.controller;
+
+import com.hamster.gro_up.dto.ApiResponse;
+import com.hamster.gro_up.dto.AuthUser;
+import com.hamster.gro_up.dto.request.ScheduleCreateRequest;
+import com.hamster.gro_up.dto.request.ScheduleUpdateRequest;
+import com.hamster.gro_up.dto.response.ScheduleListResponse;
+import com.hamster.gro_up.dto.response.ScheduleResponse;
+import com.hamster.gro_up.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "일정", description = "일정 관련 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/schedules")
+@RestController
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @Operation(summary = "일정 단건 조회")
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponse<ScheduleResponse>> findSchedule(@AuthenticationPrincipal AuthUser authUser, @PathVariable Long scheduleId) {
+        ScheduleResponse response = scheduleService.findSchedule(authUser, scheduleId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "해당 사용자의 모든 일정 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<ScheduleListResponse>> findAllSchedules(@AuthenticationPrincipal AuthUser authUser) {
+        ScheduleListResponse response = scheduleService.findAllSchedules(authUser);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "일정 생성")
+    @PostMapping
+    public ResponseEntity<ApiResponse<ScheduleResponse>> createSchedule(@AuthenticationPrincipal AuthUser authUser, @RequestBody ScheduleCreateRequest scheduleCreateRequest) {
+        ScheduleResponse response = scheduleService.createSchedule(authUser, scheduleCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.of(HttpStatus.CREATED, response));
+    }
+
+    @Operation(summary = "일정 수정")
+    @PutMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponse<Void>> updateSchedule(@AuthenticationPrincipal AuthUser authUser,
+                                                            @PathVariable long scheduleId,
+                                                            @RequestBody ScheduleUpdateRequest scheduleUpdateRequest) {
+        scheduleService.updateSchedule(authUser, scheduleId, scheduleUpdateRequest);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "일정 삭제")
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSchedule(@AuthenticationPrincipal AuthUser authUser, @PathVariable long scheduleId) {
+        scheduleService.deleteSchedule(authUser, scheduleId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
@@ -1,0 +1,22 @@
+package com.hamster.gro_up.dto.request;
+
+import com.hamster.gro_up.entity.Step;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ScheduleCreateRequest {
+
+    private Long companyId;
+
+    private Step step;
+
+    private LocalDateTime dueDate;
+
+    private String position;
+
+    private String memo;
+}

--- a/src/main/java/com/hamster/gro_up/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/ScheduleUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.hamster.gro_up.dto.request;
+
+import com.hamster.gro_up.entity.Step;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ScheduleUpdateRequest {
+
+    private Step step;
+
+    private LocalDateTime dueDate;
+
+    private String position;
+
+    private String memo;
+}

--- a/src/main/java/com/hamster/gro_up/dto/response/CompanyResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/CompanyResponse.java
@@ -4,6 +4,8 @@ import com.hamster.gro_up.entity.Company;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @AllArgsConstructor
 @Getter
 public class CompanyResponse {
@@ -18,12 +20,19 @@ public class CompanyResponse {
 
     private String location;
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
     public static CompanyResponse from(Company company) {
         return new CompanyResponse(
                 company.getId(),
                 company.getCompanyName(),
                 company.getPosition(),
                 company.getUrl(),
-                company.getLocation());
+                company.getLocation(),
+                company.getCreatedAt(),
+                company.getModifiedAt()
+        );
     }
 }

--- a/src/main/java/com/hamster/gro_up/dto/response/ScheduleListResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/ScheduleListResponse.java
@@ -1,0 +1,16 @@
+package com.hamster.gro_up.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class ScheduleListResponse {
+    List<ScheduleResponse> scheduleList;
+
+    public static ScheduleListResponse of(List<ScheduleResponse> scheduleList) {
+        return new ScheduleListResponse(scheduleList);
+    }
+}

--- a/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
@@ -1,0 +1,40 @@
+package com.hamster.gro_up.dto.response;
+
+import com.hamster.gro_up.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@Getter
+public class ScheduleResponse {
+
+    private Long companyId;
+
+    private String companyName;
+
+    private String step;
+
+    private String position;
+
+    private String memo;
+
+    private LocalDateTime dueDate;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    public static ScheduleResponse from(Schedule schedule) {
+        return new ScheduleResponse(
+                schedule.getCompany().getId(),
+                schedule.getCompany().getCompanyName(),
+                schedule.getStep().getDisplayName(),
+                schedule.getPosition(),
+                schedule.getMemo(),
+                schedule.getDueDate(),
+                schedule.getCreatedAt(),
+                schedule.getModifiedAt());
+    }
+}

--- a/src/main/java/com/hamster/gro_up/entity/Company.java
+++ b/src/main/java/com/hamster/gro_up/entity/Company.java
@@ -1,5 +1,6 @@
 package com.hamster.gro_up.entity;
 
+import com.hamster.gro_up.exception.ForbiddenException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -41,5 +42,11 @@ public class Company extends BaseEntity {
         this.position = position;
         this.location = location;
         this.url = url;
+    }
+
+    public void validateOwner(Long userId) {
+        if(!this.user.getId().equals(userId)) {
+            throw new ForbiddenException();
+        }
     }
 }

--- a/src/main/java/com/hamster/gro_up/entity/Schedule.java
+++ b/src/main/java/com/hamster/gro_up/entity/Schedule.java
@@ -1,5 +1,6 @@
 package com.hamster.gro_up.entity;
 
+import com.hamster.gro_up.exception.ForbiddenException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -43,6 +44,14 @@ public class Schedule extends BaseEntity {
         this.company = company;
         this.user = user;
     }
+
+    public void update(LocalDateTime dueDate, String memo, String position, Step step) {
+        this.dueDate = dueDate;
+        this.memo = memo;
+        this.position = position;
+        this.step = step;
+    }
+
     public void validateOwner(Long userId) {
         if(!this.user.getId().equals(userId)) {
             throw new ForbiddenException();

--- a/src/main/java/com/hamster/gro_up/entity/Schedule.java
+++ b/src/main/java/com/hamster/gro_up/entity/Schedule.java
@@ -43,4 +43,9 @@ public class Schedule extends BaseEntity {
         this.company = company;
         this.user = user;
     }
+    public void validateOwner(Long userId) {
+        if(!this.user.getId().equals(userId)) {
+            throw new ForbiddenException();
+        }
+    }
 }

--- a/src/main/java/com/hamster/gro_up/exception/ForbiddenException.java
+++ b/src/main/java/com/hamster/gro_up/exception/ForbiddenException.java
@@ -1,7 +1,7 @@
 package com.hamster.gro_up.exception;
 
 public class ForbiddenException extends RuntimeException{
-    private static final String MESSAGE = "접근이 금지되었습니다.";
+    private static final String MESSAGE = "해당 리소스에 접근할 권한이 없습니다.";
 
     public ForbiddenException() {super(MESSAGE);}
 

--- a/src/main/java/com/hamster/gro_up/exception/schedule/ScheduleNotFoundException.java
+++ b/src/main/java/com/hamster/gro_up/exception/schedule/ScheduleNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.schedule;
+
+import com.hamster.gro_up.exception.NotFoundException;
+
+public class ScheduleNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "해당 일정을 찾을 수 없습니다.";
+
+    public ScheduleNotFoundException() {super(MESSAGE);}
+
+    public ScheduleNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/repository/ScheduleRepository.java
+++ b/src/main/java/com/hamster/gro_up/repository/ScheduleRepository.java
@@ -1,0 +1,17 @@
+package com.hamster.gro_up.repository;
+
+import com.hamster.gro_up.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    @Query("select s from Schedule s join fetch s.company where s.id = :id")
+    Optional<Schedule> findByIdWithCompany(@Param("id") Long id);
+
+    @Query("select s from Schedule s join fetch s.company where s.user.id = :userId")
+    List<Schedule> findByUserIdWithCompany(@Param("userId") Long userId);
+}

--- a/src/main/java/com/hamster/gro_up/service/ScheduleService.java
+++ b/src/main/java/com/hamster/gro_up/service/ScheduleService.java
@@ -1,0 +1,92 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.dto.AuthUser;
+import com.hamster.gro_up.dto.request.ScheduleCreateRequest;
+import com.hamster.gro_up.dto.request.ScheduleUpdateRequest;
+import com.hamster.gro_up.dto.response.ScheduleListResponse;
+import com.hamster.gro_up.dto.response.ScheduleResponse;
+import com.hamster.gro_up.entity.Company;
+import com.hamster.gro_up.entity.Schedule;
+import com.hamster.gro_up.entity.User;
+import com.hamster.gro_up.exception.company.CompanyNotFoundException;
+import com.hamster.gro_up.exception.schedule.ScheduleNotFoundException;
+import com.hamster.gro_up.exception.user.UserNotFoundException;
+import com.hamster.gro_up.repository.CompanyRepository;
+import com.hamster.gro_up.repository.ScheduleRepository;
+import com.hamster.gro_up.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final CompanyRepository companyRepository;
+    private final UserRepository userRepository;
+
+    public ScheduleResponse findSchedule(AuthUser authUser, Long scheduleId) {
+        Schedule schedule = scheduleRepository.findByIdWithCompany(scheduleId).orElseThrow(ScheduleNotFoundException::new);
+
+        schedule.validateOwner(authUser.getId());
+
+        return ScheduleResponse.from(schedule);
+    }
+
+    public ScheduleListResponse findAllSchedules(AuthUser authUser) {
+        List<Schedule> scheduleList = scheduleRepository.findByUserIdWithCompany(authUser.getId());
+
+        List<ScheduleResponse> responseList = scheduleList.stream().map(ScheduleResponse::from).toList();
+
+        return ScheduleListResponse.of(responseList);
+    }
+
+    @Transactional
+    public ScheduleResponse createSchedule(AuthUser authUser, ScheduleCreateRequest scheduleCreateRequest) {
+        Company company = companyRepository.findById(scheduleCreateRequest.getCompanyId()).orElseThrow(CompanyNotFoundException::new);
+
+        company.validateOwner(authUser.getId());
+
+        User user = userRepository.findById(authUser.getId()).orElseThrow(UserNotFoundException::new);
+
+        Schedule schedule = Schedule.builder()
+                .user(user)
+                .company(company)
+                .dueDate(scheduleCreateRequest.getDueDate())
+                .step(scheduleCreateRequest.getStep())
+                .position(scheduleCreateRequest.getPosition())
+                .memo(scheduleCreateRequest.getMemo())
+                .build();
+
+        Schedule savedSchedule = scheduleRepository.save(schedule);
+
+        return ScheduleResponse.from(savedSchedule);
+    }
+
+    @Transactional
+    public void updateSchedule(AuthUser authUser, Long scheduleId, ScheduleUpdateRequest scheduleUpdateRequest) {
+        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(ScheduleNotFoundException::new);
+
+        schedule.validateOwner(authUser.getId());
+
+        schedule.update(
+                scheduleUpdateRequest.getDueDate(),
+                scheduleUpdateRequest.getMemo(),
+                scheduleUpdateRequest.getPosition(),
+                scheduleUpdateRequest.getStep()
+        );
+    }
+
+    @Transactional
+    public void deleteSchedule(AuthUser authUser, Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(ScheduleNotFoundException::new);
+
+        schedule.validateOwner(authUser.getId());
+
+        scheduleRepository.delete(schedule);
+    }
+}

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -60,7 +61,7 @@ class CompanyControllerTest {
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
     void findCompany_success() throws Exception {
         // given
-        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul");
+        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
         given(companyService.findCompany(any(), eq(10L))).willReturn(response);
 
         // when & then
@@ -78,7 +79,7 @@ class CompanyControllerTest {
     void createCompany_success() throws Exception {
         // given
         CompanyCreateRequest request = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul");
-        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul");
+        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
         given(companyService.createCompany(any(), any())).willReturn(response);
 
         // when & then

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -120,7 +120,7 @@ class CompanyControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 기업 조회 시 예외가 발생한다")
+    @DisplayName("존재하지 않는 기업 조회 시 404를 반환한다")
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
     void findCompany_notFound() throws Exception {
         // given
@@ -137,12 +137,12 @@ class CompanyControllerTest {
     @Test
     @DisplayName("기업 목록 조회에 성공한다")
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
-    void findAllCompany_success() throws Exception {
+    void findAllCompanies_success() throws Exception {
         // given
-        CompanyResponse company1 = new CompanyResponse(1L, "ham-corp", "back-end", "www.ham.com", "seoul");
-        CompanyResponse company2 = new CompanyResponse(2L, "egg-corp", "front-end", "www.egg.com", "busan");
+        CompanyResponse company1 = new CompanyResponse(1L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
+        CompanyResponse company2 = new CompanyResponse(2L, "egg-corp", "front-end", "www.egg.com", "busan", LocalDateTime.now(), LocalDateTime.now());
         CompanyListResponse companyListResponse = CompanyListResponse.of(List.of(company1, company2));
-        given(companyService.findAllCompany(any())).willReturn(companyListResponse);
+        given(companyService.findAllCompanies(any())).willReturn(companyListResponse);
 
         // when & then
         mockMvc.perform(get("/api/companies"))
@@ -160,10 +160,10 @@ class CompanyControllerTest {
     @Test
     @DisplayName("기업 목록 조회 시 하나도 없을 때 빈 리스트가 반환된다")
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
-    void findAllCompany_empty() throws Exception {
+    void findAllCompanies_empty() throws Exception {
         // given
         CompanyListResponse emptyResponse = CompanyListResponse.of(List.of());
-        given(companyService.findAllCompany(any())).willReturn(emptyResponse);
+        given(companyService.findAllCompanies(any())).willReturn(emptyResponse);
 
         // when & then
         mockMvc.perform(get("/api/companies"))

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -1,0 +1,191 @@
+package com.hamster.gro_up.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hamster.gro_up.config.*;
+import com.hamster.gro_up.dto.request.ScheduleCreateRequest;
+import com.hamster.gro_up.dto.request.ScheduleUpdateRequest;
+import com.hamster.gro_up.dto.response.ScheduleListResponse;
+import com.hamster.gro_up.dto.response.ScheduleResponse;
+import com.hamster.gro_up.entity.Role;
+import com.hamster.gro_up.entity.Step;
+import com.hamster.gro_up.exception.schedule.ScheduleNotFoundException;
+import com.hamster.gro_up.service.CustomOAuth2UserService;
+import com.hamster.gro_up.service.ScheduleService;
+import com.hamster.gro_up.util.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ScheduleController.class)
+@Import({SecurityConfig.class, JwtUtil.class})
+class ScheduleControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ScheduleService scheduleService;
+
+    @MockBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @MockBean
+    private CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @MockBean
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Test
+    @DisplayName("일정 단건 조회에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void findSchedule_success() throws Exception {
+        // given
+        ScheduleResponse response = new ScheduleResponse(
+                10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        given(scheduleService.findSchedule(any(), eq(100L))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/schedules/100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.companyId").value(10L));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 일정 조회 시 404를 반환한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void findSchedule_notFound() throws Exception {
+        // given
+        given(scheduleService.findSchedule(any(), eq(999L)))
+                .willThrow(new ScheduleNotFoundException());
+
+        // when & then
+        mockMvc.perform(get("/api/schedules/999"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    @DisplayName("해당 사용자의 모든 일정 조회에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void findAllSchedules_success() throws Exception {
+        // given
+        ScheduleResponse schedule1 = new ScheduleResponse(
+                10L, "ham-corp", "DOCUMENT", "백엔드", "메모1",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        ScheduleResponse schedule2 = new ScheduleResponse(
+                11L, "egg-corp", "INTERVIEW", "프론트엔드", "메모2",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));
+        given(scheduleService.findAllSchedules(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.scheduleList").isArray())
+                .andExpect(jsonPath("$.data.scheduleList[0].companyId").value(10L))
+                .andExpect(jsonPath("$.data.scheduleList[1].companyId").value(11L));
+    }
+
+    @Test
+    @DisplayName("일정 생성에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void createSchedule_success() throws Exception {
+        // given
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+                10L, Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
+        );
+        ScheduleResponse response = new ScheduleResponse(
+                10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        given(scheduleService.createSchedule(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/schedules")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value(201))
+                .andExpect(jsonPath("$.status").value("CREATED"))
+                .andExpect(jsonPath("$.message").value("CREATED"))
+                .andExpect(jsonPath("$.data.companyId").value(10L));
+    }
+
+    @Test
+    @DisplayName("일정 수정에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void updateSchedule_success() throws Exception {
+        // given
+        ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
+                Step.DOCUMENT, LocalDateTime.now(), "프론트엔드", "수정 메모"
+        );
+        willDoNothing().given(scheduleService).updateSchedule(any(), eq(100L), any());
+
+        // when & then
+        mockMvc.perform(put("/api/schedules/100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("일정 삭제에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void deleteSchedule_success() throws Exception {
+        // given
+        willDoNothing().given(scheduleService).deleteSchedule(any(), eq(100L));
+
+        // when & then
+        mockMvc.perform(delete("/api/schedules/100"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("일정 목록이 비어 있을 때 빈 리스트가 반환된다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    void findAllSchedules_empty() throws Exception {
+        // given
+        ScheduleListResponse emptyResponse = ScheduleListResponse.of(List.of());
+        given(scheduleService.findAllSchedules(any())).willReturn(emptyResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/schedules"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.scheduleList").isArray())
+                .andExpect(jsonPath("$.data.scheduleList").isEmpty());
+    }
+}

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -106,7 +106,8 @@ class CompanyServiceTest {
         given(companyRepository.findById(companyId)).willReturn(Optional.empty());
 
         // when & then
-        CompanyNotFoundException exception = assertThrows(CompanyNotFoundException.class, () -> companyService.findCompany(authUser, companyId));
+        CompanyNotFoundException exception = assertThrows(CompanyNotFoundException.class,
+                () -> companyService.findCompany(authUser, companyId));
         assertThat(exception.getMessage()).isEqualTo("해당 기업을 찾을 수 없습니다.");
     }
 
@@ -172,7 +173,7 @@ class CompanyServiceTest {
 
     @Test
     @DisplayName("해당 사용자가 생성한 모든 기업을 조회한다")
-    void findAllCompany_success() {
+    void findAllCompanies_success() {
         // given
         Company company2 = Company.builder()
                 .id(2L)
@@ -195,7 +196,7 @@ class CompanyServiceTest {
         given(companyRepository.findByUserId(authUser.getId())).willReturn(companyList);
 
         // when
-        CompanyListResponse response = companyService.findAllCompany(authUser);
+        CompanyListResponse response = companyService.findAllCompanies(authUser);
 
         // then
         assertThat(response.getCompanyList()).hasSize(2);
@@ -204,12 +205,12 @@ class CompanyServiceTest {
 
     @Test
     @DisplayName("해당 유저가 소유한 기업이 없으면 빈 리스트를 반환한다")
-    void findAllCompany_empty() {
+    void findAllCompanies_empty() {
         // given
         given(companyRepository.findByUserId(authUser.getId())).willReturn(List.of());
 
         // when
-        CompanyListResponse response = companyService.findAllCompany(authUser);
+        CompanyListResponse response = companyService.findAllCompanies(authUser);
 
         // then
         assertThat(response.getCompanyList()).isEmpty();

--- a/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
@@ -1,0 +1,272 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.dto.AuthUser;
+import com.hamster.gro_up.dto.request.ScheduleCreateRequest;
+import com.hamster.gro_up.dto.request.ScheduleUpdateRequest;
+import com.hamster.gro_up.dto.response.ScheduleListResponse;
+import com.hamster.gro_up.dto.response.ScheduleResponse;
+import com.hamster.gro_up.entity.*;
+import com.hamster.gro_up.exception.ForbiddenException;
+import com.hamster.gro_up.exception.schedule.ScheduleNotFoundException;
+import com.hamster.gro_up.repository.CompanyRepository;
+import com.hamster.gro_up.repository.ScheduleRepository;
+import com.hamster.gro_up.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleServiceTest {
+
+    @Mock
+    private ScheduleRepository scheduleRepository;
+
+    @Mock
+    private CompanyRepository companyRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ScheduleService scheduleService;
+
+    private User user;
+    private Company company;
+    private Schedule schedule;
+    private AuthUser authUser;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .build();
+
+        company = Company.builder()
+                .id(10L)
+                .user(user)
+                .companyName("ham-corp")
+                .position("back-end")
+                .location("seoul")
+                .url("www.ham.com")
+                .build();
+
+        schedule = Schedule.builder()
+                .id(100L)
+                .user(user)
+                .company(company)
+                .dueDate(LocalDateTime.of(2025, 5, 11, 12, 0))
+                .step(Step.DOCUMENT)
+                .position("백엔드")
+                .memo("메모입니다")
+                .build();
+
+        authUser = new AuthUser(1L, "ham@gmail.com", "ham", Role.ROLE_USER);
+    }
+
+    @Test
+    @DisplayName("일정 단건 조회에 성공한다")
+    void findSchedule_success() {
+        // given
+        given(scheduleRepository.findByIdWithCompany(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when
+        ScheduleResponse response = scheduleService.findSchedule(authUser, schedule.getId());
+
+        // then
+        assertThat(response.getCompanyId()).isEqualTo(company.getId());
+        assertThat(response.getCompanyName()).isEqualTo(company.getCompanyName());
+        assertThat(response.getStep()).isEqualTo(schedule.getStep().getDisplayName());
+        assertThat(response.getPosition()).isEqualTo(schedule.getPosition());
+        assertThat(response.getMemo()).isEqualTo(schedule.getMemo());
+        assertThat(response.getDueDate()).isEqualTo(schedule.getDueDate());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 일정 조회 시 예외가 발생한다")
+    void findSchedule_fail_notExist() {
+        // given
+        given(scheduleRepository.findByIdWithCompany(999L)).willReturn(Optional.empty());
+
+        // when & then
+        ScheduleNotFoundException exception = assertThrows(ScheduleNotFoundException.class,
+                () -> scheduleService.findSchedule(authUser, 999L));
+        assertThat(exception.getMessage()).isEqualTo("해당 일정을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("일정 조회 시 소유자가 아니면 예외가 발생한다")
+    void findSchedule_fail_notOwner() {
+        // given
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        given(scheduleRepository.findByIdWithCompany(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when & then
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> scheduleService.findSchedule(otherUser, schedule.getId()));
+        assertThat(exception.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("해당 사용자가 생성한 모든 일정을 조회한다")
+    void findAllSchedules_success() {
+        // given
+        Schedule schedule2 = Schedule.builder()
+                .id(101L)
+                .user(user)
+                .company(company)
+                .dueDate(LocalDateTime.of(2024, 6, 2, 14, 0))
+                .step(Step.SECOND_INTERVIEW)
+                .position("프론트엔드")
+                .memo("2차 면접")
+                .build();
+
+        List<Schedule> scheduleList = List.of(schedule, schedule2);
+        given(scheduleRepository.findByUserIdWithCompany(authUser.getId())).willReturn(scheduleList);
+
+        // when
+        ScheduleListResponse response = scheduleService.findAllSchedules(authUser);
+
+        // then
+        assertThat(response.getScheduleList()).hasSize(2);
+        assertThat(response.getScheduleList()).extracting("position").contains("백엔드", "프론트엔드");
+    }
+
+    @Test
+    @DisplayName("해당 사용자가 소유한 일정이 없으면 빈 리스트를 반환한다")
+    void findAllSchedules_empty() {
+        // given
+        given(scheduleRepository.findByUserIdWithCompany(authUser.getId())).willReturn(List.of());
+
+        // when
+        ScheduleListResponse response = scheduleService.findAllSchedules(authUser);
+
+        // then
+        assertThat(response.getScheduleList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("일정 생성에 성공한다")
+    void createSchedule_success() {
+        // given
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+                company.getId(),
+                schedule.getStep(),
+                schedule.getDueDate(),
+                schedule.getPosition(),
+                schedule.getMemo()
+        );
+        given(companyRepository.findById(company.getId())).willReturn(Optional.of(company));
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        given(scheduleRepository.save(any(Schedule.class))).willReturn(schedule);
+
+        // when
+        ScheduleResponse response = scheduleService.createSchedule(authUser, request);
+
+        // then
+        assertThat(response.getCompanyId()).isEqualTo(company.getId());
+        assertThat(response.getCompanyName()).isEqualTo(company.getCompanyName());
+        assertThat(response.getStep()).isEqualTo(schedule.getStep().getDisplayName());
+        assertThat(response.getPosition()).isEqualTo(schedule.getPosition());
+        assertThat(response.getMemo()).isEqualTo(schedule.getMemo());
+        assertThat(response.getDueDate()).isEqualTo(schedule.getDueDate());
+    }
+
+    @Test
+    @DisplayName("일정 생성 시 소유자가 아니면 예외가 발생한다")
+    void createSchedule_fail_notOwner() {
+        // given
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        ScheduleCreateRequest request = new ScheduleCreateRequest(
+                company.getId(),
+                schedule.getStep(),
+                schedule.getDueDate(),
+                schedule.getPosition(),
+                schedule.getMemo()
+        );
+        given(companyRepository.findById(company.getId())).willReturn(Optional.of(company));
+
+        // when & then
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> scheduleService.createSchedule(otherUser, request));
+        assertThat(exception.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("일정 수정에 성공한다")
+    void updateSchedule_success() {
+        // given
+        ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
+                Step.DOCUMENT,
+                LocalDateTime.of(2025, 6, 12, 10, 0),
+                "수정된 메모",
+                "프론트엔드"
+        );
+        given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when
+        scheduleService.updateSchedule(authUser, schedule.getId(), updateRequest);
+
+        // then
+        assertThat(schedule.getDueDate()).isEqualTo(updateRequest.getDueDate());
+        assertThat(schedule.getMemo()).isEqualTo(updateRequest.getMemo());
+        assertThat(schedule.getPosition()).isEqualTo(updateRequest.getPosition());
+        assertThat(schedule.getStep()).isEqualTo(Step.DOCUMENT);
+    }
+
+    @Test
+    @DisplayName("일정 수정 시 소유자가 아니면 예외가 발생한다")
+    void updateSchedule_fail_notOwner() {
+        // given
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
+                Step.DOCUMENT, LocalDateTime.now(), "백엔드", "메모 수정"
+        );
+        given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when & then
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> scheduleService.updateSchedule(otherUser, schedule.getId(), updateRequest));
+        assertThat(exception.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("일정 삭제에 성공한다")
+    void deleteSchedule_success() {
+        // given
+        given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when
+        scheduleService.deleteSchedule(authUser, schedule.getId());
+
+        // then
+        verify(scheduleRepository).delete(schedule);
+    }
+
+    @Test
+    @DisplayName("일정 삭제 시 소유자가 아니면 예외가 발생한다")
+    void deleteSchedule_fail_notOwner() {
+        // given
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
+
+        // when & then
+        ForbiddenException exception = assertThrows(ForbiddenException.class,
+                () -> scheduleService.deleteSchedule(otherUser, schedule.getId()));
+        assertThat(exception.getMessage()).isEqualTo("해당 리소스에 접근할 권한이 없습니다.");
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
일정 기본 CRUD 를 구현했습니다.

## 작업 상세
* 일정 단건 조회, 모든 조회, 생성, 수정, 삭제 구현 및 테스트 코드 작성 완료
* 작성자 검증 로직을 entity 클래스 안으로 이동
* `기업` 응답 DTO 에 생성일, 수정일 추가

## 관련 이슈
This closes #5 , #51 