### PR TITLE
refactor: `user` 테이블의 `name` 컬럼 삭제와 그에 따른 코드 수정

### DIFF
--- a/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
@@ -22,11 +22,11 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
         Long userId = customOAuth2User.getId();
         String email = customOAuth2User.getAttribute("email");
-        String name = customOAuth2User.getAttribute("name");
 
-        String token = jwtUtil.createToken(userId, email, name, Role.ROLE_USER);
+        String token = jwtUtil.createToken(userId, email, Role.ROLE_USER);
 
         response.setContentType("application/json");
         response.getWriter().write(token);

--- a/src/main/java/com/hamster/gro_up/config/JwtSecurityFilter.java
+++ b/src/main/java/com/hamster/gro_up/config/JwtSecurityFilter.java
@@ -37,11 +37,10 @@ public class JwtSecurityFilter extends OncePerRequestFilter {
                 Claims claims = jwtUtil.extractClaims(jwt);
                 Long userId = Long.valueOf(claims.getSubject());
                 String email = claims.get("email", String.class);
-                String name = claims.get("name", String.class);
                 Role role = Role.of(claims.get("role", String.class));
 
                 if (SecurityContextHolder.getContext().getAuthentication() == null) {
-                    AuthUser authUser = new AuthUser(userId, email, name, role);
+                    AuthUser authUser = new AuthUser(userId, email, role);
                     JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
                     SecurityContextHolder.getContext().setAuthentication(authenticationToken);
                 }

--- a/src/main/java/com/hamster/gro_up/dto/AuthUser.java
+++ b/src/main/java/com/hamster/gro_up/dto/AuthUser.java
@@ -13,13 +13,11 @@ public class AuthUser {
 
     private final Long id;
     private final String email;
-    private final String name;
     private final Collection<? extends GrantedAuthority> authorities;
 
-    public AuthUser(Long id, String email, String name, Role role) {
+    public AuthUser(Long id, String email, Role role) {
         this.id = id;
         this.email = email;
-        this.name = name;
         if (role == Role.ROLE_ADMIN) {
             this.authorities = List.of(
                     new SimpleGrantedAuthority(Role.ROLE_ADMIN.name()),

--- a/src/main/java/com/hamster/gro_up/dto/request/SignupRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/SignupRequest.java
@@ -12,8 +12,5 @@ public class SignupRequest {
     private String email;
 
     @NotBlank
-    private String name;
-
-    @NotBlank
     private String password;
 }

--- a/src/main/java/com/hamster/gro_up/entity/User.java
+++ b/src/main/java/com/hamster/gro_up/entity/User.java
@@ -18,17 +18,14 @@ public class User extends BaseEntity {
 
     private String password;
 
-    private String name;
-
     @Enumerated(EnumType.STRING)
     private Role role;
 
     @Builder
-    public User(Long id, String email, String password, String name, Role role) {
+    public User(Long id, String email, String password, Role role) {
         this.id = id;
         this.email = email;
         this.password = password;
-        this.name = name;
         this.role = role;
     }
 }

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -41,13 +41,12 @@ public class AuthService {
 
         User user = User.builder()
                 .email(signupRequest.getEmail())
-                .name(signupRequest.getName())
                 .password(encodedPassword)
                 .role(Role.ROLE_USER)
                 .build();
 
         User savedUser = userRepository.save(user);
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getName(), savedUser.getRole());
+        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getRole());
 
         return new TokenResponse(bearerToken);
     }
@@ -60,7 +59,7 @@ public class AuthService {
             throw new InvalidCredentialsException();
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getName(), user.getRole());
+        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
 
         return new TokenResponse(bearerToken);
     }

--- a/src/main/java/com/hamster/gro_up/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/hamster/gro_up/service/CustomOAuth2UserService.java
@@ -21,13 +21,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String email = oAuth2User.getAttribute("email");
-        String name = oAuth2User.getAttribute("name");
 
         User user = userRepository.findByEmail(email)
                 .orElseGet(() -> userRepository.save(
                         User.builder()
                                 .email(email)
-                                .name(name)
                                 .role(Role.ROLE_USER)
                                 .build()
                 ));

--- a/src/main/java/com/hamster/gro_up/util/JwtUtil.java
+++ b/src/main/java/com/hamster/gro_up/util/JwtUtil.java
@@ -30,14 +30,13 @@ public class JwtUtil {
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    public String createToken(Long userId, String email, String name, Role role) {
+    public String createToken(Long userId, String email, Role role) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                Jwts.builder()
                        .setSubject(String.valueOf(userId))
                        .claim("email", email)
-                       .claim("name", name)
                        .claim("role", role)
                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
                        .setIssuedAt(date) // 발급일

--- a/src/main/resources/db/migration/V3__drop_name_column_from_user.sql
+++ b/src/main/resources/db/migration/V3__drop_name_column_from_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user DROP COLUMN name;

--- a/src/test/java/com/hamster/gro_up/config/WithMockAuthUser.java
+++ b/src/test/java/com/hamster/gro_up/config/WithMockAuthUser.java
@@ -11,6 +11,5 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithMockAuthUser {
     long userId();
     String email();
-    String name();
     Role role();
 }

--- a/src/test/java/com/hamster/gro_up/config/WithMockAuthUserSecurityContextFactory.java
+++ b/src/test/java/com/hamster/gro_up/config/WithMockAuthUserSecurityContextFactory.java
@@ -11,7 +11,7 @@ public class WithMockAuthUserSecurityContextFactory implements WithSecurityConte
     public SecurityContext createSecurityContext(WithMockAuthUser customUser) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-        AuthUser authUser = new AuthUser(customUser.userId(), customUser.email(), customUser.name(), customUser.role());
+        AuthUser authUser = new AuthUser(customUser.userId(), customUser.email(), customUser.role());
         JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
 
         context.setAuthentication(authenticationToken);

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -64,7 +64,7 @@ class AuthControllerTest {
     @DisplayName("회원가입에 성공하면 토큰을 반환한다")
     void signup_success() throws Exception {
         // given
-        SignupRequest signupRequest = new SignupRequest("test@test.com", "test", "password");
+        SignupRequest signupRequest = new SignupRequest("test@test.com", "password");
         TokenResponse token = new TokenResponse("token");
         given(authService.signup(any(SignupRequest.class))).willReturn(token);
 
@@ -103,12 +103,8 @@ class AuthControllerTest {
     @DisplayName("필수값이 누락된 회원가입 요청 시 예외가 발생한다")
     void signup_fail_validation() throws Exception {
         // given
-        SignupRequest invalidRequest = new SignupRequest(
-                "",
-                "hamster",
-                "password123"
-        );
-        
+        SignupRequest invalidRequest = new SignupRequest("", "password123");
+
         // when & then
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -58,7 +58,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 조회에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findCompany_success() throws Exception {
         // given
         CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
@@ -75,7 +75,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 등록에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void createCompany_success() throws Exception {
         // given
         CompanyCreateRequest request = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul");
@@ -95,7 +95,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 수정에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void updateCompany_success() throws Exception {
         // given
         CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "www.new.com", "busan");
@@ -110,7 +110,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 삭제에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void deleteCompany_success() throws Exception {
         // given
         willDoNothing().given(companyService).deleteCompany(any(), eq(10L));
@@ -122,7 +122,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("존재하지 않는 기업 조회 시 404를 반환한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findCompany_notFound() throws Exception {
         // given
         given(companyService.findCompany(any(), eq(999L)))
@@ -137,7 +137,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 목록 조회에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findAllCompanies_success() throws Exception {
         // given
         CompanyResponse company1 = new CompanyResponse(1L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
@@ -160,7 +160,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("기업 목록 조회 시 하나도 없을 때 빈 리스트가 반환된다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findAllCompanies_empty() throws Exception {
         // given
         CompanyListResponse emptyResponse = CompanyListResponse.of(List.of());
@@ -176,7 +176,7 @@ class CompanyControllerTest {
 
     @Test
     @DisplayName("필수값이 누락된 기업 등록 요청 시 예외가 발생한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void createCompany_fail_validation() throws Exception {
         // given
         CompanyCreateRequest invalidRequest = new CompanyCreateRequest(

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -59,7 +59,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("일정 단건 조회에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findSchedule_success() throws Exception {
         // given
         ScheduleResponse response = new ScheduleResponse(
@@ -79,7 +79,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("존재하지 않는 일정 조회 시 404를 반환한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findSchedule_notFound() throws Exception {
         // given
         given(scheduleService.findSchedule(any(), eq(999L)))
@@ -94,7 +94,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("해당 사용자의 모든 일정 조회에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findAllSchedules_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
@@ -121,7 +121,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("일정 생성에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void createSchedule_success() throws Exception {
         // given
         ScheduleCreateRequest request = new ScheduleCreateRequest(
@@ -146,7 +146,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("일정 수정에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void updateSchedule_success() throws Exception {
         // given
         ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
@@ -163,7 +163,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("일정 삭제에 성공한다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void deleteSchedule_success() throws Exception {
         // given
         willDoNothing().given(scheduleService).deleteSchedule(any(), eq(100L));
@@ -175,7 +175,7 @@ class ScheduleControllerTest {
 
     @Test
     @DisplayName("일정 목록이 비어 있을 때 빈 리스트가 반환된다")
-    @WithMockAuthUser(userId = 1L, email = "ham@example.com", name = "ham", role = Role.ROLE_USER)
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findAllSchedules_empty() throws Exception {
         // given
         ScheduleListResponse emptyResponse = ScheduleListResponse.of(List.of());

--- a/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
@@ -52,14 +52,13 @@ class AuthServiceTest {
 
     @BeforeEach
     void setup() {
-        signupRequest = new SignupRequest("test@example.com", "test", "password");
+        signupRequest = new SignupRequest("test@example.com", "password");
         signinRequest = new SigninRequest("test@example.com", "testpw");
 
         user = User.builder()
                 .id(1L)
                 .email("test@test.com")
                 .password("password")
-                .name("ham")
                 .password("encoded_password")
                 .role(Role.ROLE_USER)
                 .build();
@@ -72,7 +71,7 @@ class AuthServiceTest {
         given(userRepository.existsByEmail(signupRequest.getEmail())).willReturn(false);
         given(passwordEncoder.encode(signupRequest.getPassword())).willReturn("encoded_password");
         given(userRepository.save(any(User.class))).willReturn(user);
-        given(jwtUtil.createToken(anyLong(), anyString(), anyString(), any(Role.class))).willReturn("token");
+        given(jwtUtil.createToken(anyLong(), anyString(), any(Role.class))).willReturn("token");
         given(emailVerificationService.isEmailVerified(signupRequest.getEmail())).willReturn(true);
 
         // when
@@ -101,7 +100,7 @@ class AuthServiceTest {
         // given
         given(userRepository.findByEmail(signinRequest.getEmail())).willReturn(Optional.of(user));
         given(passwordEncoder.matches(signinRequest.getPassword(), user.getPassword())).willReturn(true);
-        given(jwtUtil.createToken(anyLong(), anyString(), anyString(), any(Role.class))).willReturn("token");
+        given(jwtUtil.createToken(anyLong(), anyString(), any(Role.class))).willReturn("token");
 
         // when
         TokenResponse response = authService.signin(signinRequest);

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -60,7 +60,7 @@ class CompanyServiceTest {
                 .url("www.ham.com")
                 .build();
 
-        authUser = new AuthUser(1L, "ham@gmail.com", "ham", Role.ROLE_USER);
+        authUser = new AuthUser(1L, "ham@gmail.com", Role.ROLE_USER);
     }
 
     @Test
@@ -133,7 +133,7 @@ class CompanyServiceTest {
     @DisplayName("기업 수정 시 소유자가 아니면 예외가 발생한다")
     void updateCompany_fail_notOwner() {
         // given
-        AuthUser otherAuthUser = new AuthUser(2L, "other-user", "other-auth-user", Role.ROLE_USER);
+        AuthUser otherAuthUser = new AuthUser(2L, "other-user", Role.ROLE_USER);
         CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "busan", "www.new.com");
         given(companyRepository.findById(10L)).willReturn(Optional.of(company));
 
@@ -161,7 +161,7 @@ class CompanyServiceTest {
     @DisplayName("기업 삭제 시 소유자가 아니면 예외가 발생한다")
     void deleteCompany_fail_notOwner() {
         // given
-        AuthUser otherAuthUser = new AuthUser(2L, "other-user", "other-auth-user", Role.ROLE_USER);
+        AuthUser otherAuthUser = new AuthUser(2L, "other-user", Role.ROLE_USER);
         given(companyRepository.findById(10L)).willReturn(Optional.of(company));
 
         // when & then

--- a/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
@@ -74,7 +74,7 @@ class ScheduleServiceTest {
                 .memo("메모입니다")
                 .build();
 
-        authUser = new AuthUser(1L, "ham@gmail.com", "ham", Role.ROLE_USER);
+        authUser = new AuthUser(1L, "ham@gmail.com", Role.ROLE_USER);
     }
 
     @Test
@@ -111,7 +111,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 조회 시 소유자가 아니면 예외가 발생한다")
     void findSchedule_fail_notOwner() {
         // given
-        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", Role.ROLE_USER);
         given(scheduleRepository.findByIdWithCompany(schedule.getId())).willReturn(Optional.of(schedule));
 
         // when & then
@@ -189,7 +189,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 생성 시 소유자가 아니면 예외가 발생한다")
     void createSchedule_fail_notOwner() {
         // given
-        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", Role.ROLE_USER);
         ScheduleCreateRequest request = new ScheduleCreateRequest(
                 company.getId(),
                 schedule.getStep(),
@@ -231,7 +231,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 수정 시 소유자가 아니면 예외가 발생한다")
     void updateSchedule_fail_notOwner() {
         // given
-        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", Role.ROLE_USER);
         ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
                 Step.DOCUMENT, LocalDateTime.now(), "백엔드", "메모 수정"
         );
@@ -260,7 +260,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 삭제 시 소유자가 아니면 예외가 발생한다")
     void deleteSchedule_fail_notOwner() {
         // given
-        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", "other", Role.ROLE_USER);
+        AuthUser otherUser = new AuthUser(2L, "other@gmail.com", Role.ROLE_USER);
         given(scheduleRepository.findById(schedule.getId())).willReturn(Optional.of(schedule));
 
         // when & then


### PR DESCRIPTION
## 작업 내용
사용자의 이름을 더 이상 사용하지 않기에 `user` 테이블의 `name` 컬럼 삭제 및 그에 따른 코드 수정을 하였습니다.

## 관련 이슈
This closes #55 