### PR TITLE
fix: AWS SES 사용 및 `setFrom` 지정

### DIFF
--- a/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
+++ b/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
@@ -6,6 +6,7 @@ import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.repository.EmailVerificationTokenRepository;
 import com.hamster.gro_up.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,9 @@ public class EmailVerificationService {
     private final EmailVerificationTokenRepository tokenRepository;
     private final UserRepository userRepository;
     private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.from}")
+    private String fromAddress;
 
     @Transactional
     public void sendVerificationCode(String email) {
@@ -44,6 +48,7 @@ public class EmailVerificationService {
 
         // 이메일 발송
         SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromAddress);
         message.setTo(email);
         message.setSubject("이메일 인증 코드");
         message.setText("인증 코드: " + code);


### PR DESCRIPTION
## 작업 내용 
인증 코드 발송 메일이 스팸으로 들어가는 문제가 발생했기에 gmail smtp 를 이용하는 것이 아닌 AWS SES smtp 를 이용하는 것으로 변경했습니다.

## 작업 상세
* `application-prod.yml` 에서 smtp 관련 설정 값들을 수정했습니다.
* `setFrom` 을 지정하여 `no-reply@gro-up.shop` 으로 메일이 발송되도록 하였습니다.

## 관련 이슈
This closes #63 