### PR TITLE
feat: Refresh Token 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 
 	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hamster/gro_up/config/RedisConfig.java
+++ b/src/main/java/com/hamster/gro_up/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.hamster.gro_up.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -6,10 +6,15 @@ import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.service.AuthService;
 import com.hamster.gro_up.service.EmailVerificationService;
+import com.hamster.gro_up.util.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,16 +29,36 @@ public class AuthController {
 
     @Operation(summary = "일반 회원가입")
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<TokenResponse>> signup(@Valid @RequestBody SignupRequest signupRequest) {
-        TokenResponse response = authService.signup(signupRequest);
+    public ResponseEntity<ApiResponse<TokenResponse>> signUp(@Valid @RequestBody SignupRequest signupRequest) {
+        TokenResponse response = authService.signUp(signupRequest);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
     @Operation(summary = "일반 로그인")
     @PostMapping("/signin")
-    public ResponseEntity<ApiResponse<TokenResponse>> signin(@Valid @RequestBody SigninRequest signinRequest) {
-        TokenResponse response = authService.signin(signinRequest);
+    public ResponseEntity<ApiResponse<TokenResponse>> signIn(@Valid @RequestBody SigninRequest signinRequest) {
+        TokenResponse response = authService.signIn(signinRequest);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "로그아웃")
+    @PostMapping("/sign-out")
+    public ResponseEntity<ApiResponse<Void>> signOut(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = CookieUtil.extractCookie(request, "refresh");
+
+        if (refreshToken == null) {
+            return ResponseEntity
+                    .badRequest()
+                    .body(ApiResponse.of(HttpStatus.BAD_REQUEST, "Refresh Token 이 존재하지 않습니다.", null));
+        }
+
+        authService.signOut(refreshToken);
+
+        // refresh 쿠키 만료(삭제)
+        Cookie expiredCookie = CookieUtil.createExpiredCookie(CookieUtil.REFRESH_TOKEN_COOKIE_NAME);
+        response.addCookie(expiredCookie);
+
+        return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
     @Operation(summary = "이메일 인증 요청")

--- a/src/main/java/com/hamster/gro_up/controller/RetrospectController.java
+++ b/src/main/java/com/hamster/gro_up/controller/RetrospectController.java
@@ -8,6 +8,7 @@ import com.hamster.gro_up.dto.response.RetrospectListResponse;
 import com.hamster.gro_up.dto.response.RetrospectResponse;
 import com.hamster.gro_up.service.RetrospectService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "회고", description = "회고 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/retrospects")
 @RestController

--- a/src/main/java/com/hamster/gro_up/dto/ApiResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/ApiResponse.java
@@ -11,11 +11,22 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
+    public ApiResponse(int code, HttpStatus status, String message, T data) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
     public ApiResponse(HttpStatus status, String message, T data) {
         this.code = status.value();
         this.status = status;
         this.data = data;
         this.message = message;
+    }
+
+    public static <T> ApiResponse<T> of(int code, HttpStatus status, String message, T data) {
+        return new ApiResponse<>(code, status, message, data);
     }
 
     public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {

--- a/src/main/java/com/hamster/gro_up/dto/AuthUser.java
+++ b/src/main/java/com/hamster/gro_up/dto/AuthUser.java
@@ -1,30 +1,33 @@
 package com.hamster.gro_up.dto;
 
 import com.hamster.gro_up.entity.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+@AllArgsConstructor
+@Builder
 @Getter
 public class AuthUser {
 
-    private final Long id;
-    private final String email;
-    private final Collection<? extends GrantedAuthority> authorities;
+    private Long id;
+    private String email;
+    private Role role;
 
-    public AuthUser(Long id, String email, Role role) {
-        this.id = id;
-        this.email = email;
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(role.name()));
+
         if (role == Role.ROLE_ADMIN) {
-            this.authorities = List.of(
-                    new SimpleGrantedAuthority(Role.ROLE_ADMIN.name()),
-                    new SimpleGrantedAuthority(Role.ROLE_USER.name())
-            );
-        } else {
-            this.authorities = List.of(new SimpleGrantedAuthority(role.name()));
+            authorities.add(new SimpleGrantedAuthority(Role.ROLE_USER.name()));
         }
+
+        return authorities;
     }
 }

--- a/src/main/java/com/hamster/gro_up/dto/response/TokenResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/TokenResponse.java
@@ -6,5 +6,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class TokenResponse {
-    private String token;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
 }

--- a/src/main/java/com/hamster/gro_up/exception/auth/ExpiredTokenException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/ExpiredTokenException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.UnauthorizedException;
+
+public class ExpiredTokenException extends UnauthorizedException {
+    private static final String MESSAGE = "만료된 토큰입니다.";
+
+    public ExpiredTokenException() {super(MESSAGE);}
+
+    public ExpiredTokenException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/auth/InvalidTokenException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.UnauthorizedException;
+
+public class InvalidTokenException extends UnauthorizedException {
+    private static final String MESSAGE = "올바르지 않은 토큰입니다.";
+
+    public InvalidTokenException() {super(MESSAGE);}
+
+    public InvalidTokenException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/auth/TokenNotFoundException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/TokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.UnauthorizedException;
+
+public class TokenNotFoundException extends UnauthorizedException {
+    private static final String MESSAGE = "토큰을 찾을 수 없습니다.";
+
+    public TokenNotFoundException() {super(MESSAGE);}
+
+    public TokenNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/auth/TokenTypeMismatchException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/TokenTypeMismatchException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.UnauthorizedException;
+
+public class TokenTypeMismatchException extends UnauthorizedException {
+    private static final String MESSAGE = "Token type 이 일치하지 않습니다.";
+
+    public TokenTypeMismatchException() {super(MESSAGE);}
+
+    public TokenTypeMismatchException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -1,21 +1,24 @@
 package com.hamster.gro_up.service;
 
+import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
 import com.hamster.gro_up.entity.User;
-import com.hamster.gro_up.exception.auth.EmailNotVerifiedException;
-import com.hamster.gro_up.exception.auth.InvalidCredentialsException;
+import com.hamster.gro_up.exception.auth.*;
 import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.exception.user.UserNotFoundException;
 import com.hamster.gro_up.repository.UserRepository;
 import com.hamster.gro_up.util.JwtUtil;
+import com.hamster.gro_up.util.TokenType;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -24,16 +27,16 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final EmailVerificationService emailVerificationService;
+    private final RefreshTokenService refreshTokenService;
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public TokenResponse signup(SignupRequest signupRequest) {
-
+    public TokenResponse signUp(SignupRequest signupRequest) {
         if (userRepository.existsByEmail(signupRequest.getEmail())) {
             throw new DuplicateUserException();
         }
 
-        if(!emailVerificationService.isEmailVerified(signupRequest.getEmail())) {
+        if (!emailVerificationService.isEmailVerified(signupRequest.getEmail())) {
             throw new EmailNotVerifiedException();
         }
 
@@ -46,12 +49,16 @@ public class AuthService {
                 .build();
 
         User savedUser = userRepository.save(user);
-        String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getRole());
 
-        return new TokenResponse(bearerToken);
+        String accessToken = jwtUtil.createToken(TokenType.ACCESS, savedUser.getId(), savedUser.getEmail(), savedUser.getRole());
+        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, savedUser.getId(), savedUser.getEmail(), savedUser.getRole());
+
+        refreshTokenService.saveRefreshToken(refreshToken, savedUser.getEmail());
+
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
-    public TokenResponse signin(SigninRequest signinRequest) {
+    public TokenResponse signIn(SigninRequest signinRequest) {
         User user = userRepository.findByEmail(signinRequest.getEmail()).orElseThrow(
                 UserNotFoundException::new);
 
@@ -59,8 +66,69 @@ public class AuthService {
             throw new InvalidCredentialsException();
         }
 
-        String bearerToken = jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+        String accessToken = jwtUtil.createToken(TokenType.ACCESS, user.getId(), user.getEmail(), user.getRole());
+        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, user.getId(), user.getEmail(), user.getRole());
 
-        return new TokenResponse(bearerToken);
+        refreshTokenService.saveRefreshToken(refreshToken, user.getEmail());
+
+        return TokenResponse.of(accessToken, refreshToken);
+    }
+
+    public void signOut(String refreshToken) {
+        if (jwtUtil.isExpired(refreshToken)) {
+            throw new ExpiredTokenException();
+        }
+
+        String tokenType = jwtUtil.getTokenType(refreshToken);
+        if (!tokenType.equalsIgnoreCase(TokenType.REFRESH.name())) {
+            throw new InvalidTokenException("Refresh Token 이 아닙니다.");
+        }
+
+        String email = jwtUtil.getEmail(refreshToken);
+        if (!refreshTokenService.existsByEmail(email)) {
+            throw new InvalidTokenException("이미 로그아웃된 사용자입니다.");
+        }
+
+        refreshTokenService.deleteRefreshToken(email);
+    }
+
+    public TokenResponse reissueAccessToken(String refreshToken) {
+        if (refreshToken == null) {
+            throw new InvalidTokenException();
+        }
+
+        if (jwtUtil.isExpired(refreshToken)) {
+            throw new ExpiredTokenException();
+        }
+
+        String tokenType = jwtUtil.getTokenType(refreshToken);
+        if (!tokenType.equalsIgnoreCase(TokenType.REFRESH.name())) {
+            throw new TokenTypeMismatchException();
+        }
+
+        AuthUser authUser = jwtUtil.getAuthUserFromToken(refreshToken);
+        String email = authUser.getEmail();
+
+        String storedRefreshToken = refreshTokenService.getRefreshToken(authUser.getEmail());
+        if (storedRefreshToken == null) {
+            throw new TokenNotFoundException();
+        }
+
+        log.info("storedRefreshToken: {}", storedRefreshToken);
+        log.info("refreshToken from request: {}", refreshToken);
+        log.info("equals: {}", storedRefreshToken.equals(refreshToken));
+
+        if (!storedRefreshToken.equals(refreshToken)) {
+            throw new InvalidTokenException("Refresh Token 이 일치하지 않습니다.");
+        }
+
+        String newAccessToken = jwtUtil.createToken(TokenType.ACCESS, authUser.getId(), email, authUser.getRole());
+        String newRefreshToken = jwtUtil.createToken(TokenType.REFRESH, authUser.getId(), email, authUser.getRole());
+
+        // Refresh Token Rotation (RTR)
+        refreshTokenService.deleteRefreshToken(email);
+        refreshTokenService.saveRefreshToken(newRefreshToken, email);
+
+        return TokenResponse.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/hamster/gro_up/service/RefreshTokenService.java
+++ b/src/main/java/com/hamster/gro_up/service/RefreshTokenService.java
@@ -1,0 +1,40 @@
+package com.hamster.gro_up.service;
+
+import com.hamster.gro_up.util.TokenType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveRefreshToken(String token, String email) {
+        String key = getRefreshTokenKey(email);
+        long expireMs = TokenType.REFRESH.getExpireMs();
+        redisTemplate.opsForValue().set(key, token, expireMs, TimeUnit.MILLISECONDS);
+    }
+
+    public String getRefreshToken(String email) {
+        String key = getRefreshTokenKey(email);
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteRefreshToken(String email) {
+        String key = getRefreshTokenKey(email);
+        redisTemplate.delete(key);
+    }
+
+    public boolean existsByEmail(String email) {
+        String key = getRefreshTokenKey(email);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    private String getRefreshTokenKey(String email) {
+        return "refreshToken:" + email;
+    }
+}

--- a/src/main/java/com/hamster/gro_up/util/CookieUtil.java
+++ b/src/main/java/com/hamster/gro_up/util/CookieUtil.java
@@ -1,0 +1,36 @@
+package com.hamster.gro_up.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtil {
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh";
+
+    public static String extractCookie(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    public static Cookie createExpiredCookie(String name) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        return cookie;
+    }
+
+    public static Cookie createCookie(String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setMaxAge(maxAge);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true); // 운영환경에서만 true
+        return cookie;
+    }
+}

--- a/src/main/java/com/hamster/gro_up/util/TokenType.java
+++ b/src/main/java/com/hamster/gro_up/util/TokenType.java
@@ -1,0 +1,16 @@
+package com.hamster.gro_up.util;
+
+public enum TokenType {
+    ACCESS(60 * 60 * 1000L),         // 1시간
+    REFRESH(14 * 24 * 60 * 60 * 1000L); // 2주
+
+    private final long expireMs;
+
+    TokenType(long expireMs) {
+        this.expireMs = expireMs;
+    }
+
+    public long getExpireMs() {
+        return expireMs;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,7 @@ spring:
               - profile
               - email
   mail:
+    from: ${MAIL_FROM}
     host: smtp.gmail.com
     port: 587
     username: ${MAIL_USERNAME}
@@ -39,6 +40,10 @@ spring:
     url: ${LOCAL_DB_URL}
     user: root # MySQL 사용자 이름
     password: ${LOCAL_DB_PASSWORD}
+  data:
+    redis:
+      host: localhost
+      port: 6379
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}  # JWT 비밀 키

--- a/src/test/java/com/hamster/gro_up/config/WithMockAuthUserSecurityContextFactory.java
+++ b/src/test/java/com/hamster/gro_up/config/WithMockAuthUserSecurityContextFactory.java
@@ -11,7 +11,7 @@ public class WithMockAuthUserSecurityContextFactory implements WithSecurityConte
     public SecurityContext createSecurityContext(WithMockAuthUser customUser) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
 
-        AuthUser authUser = new AuthUser(customUser.userId(), customUser.email(), customUser.role());
+        AuthUser authUser = AuthUser.builder().id(customUser.userId()).email(customUser.email()).role(customUser.role()).build();
         JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
 
         context.setAuthentication(authenticationToken);

--- a/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/AuthServiceTest.java
@@ -1,15 +1,17 @@
 package com.hamster.gro_up.service;
 
+import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
 import com.hamster.gro_up.entity.User;
-import com.hamster.gro_up.exception.auth.InvalidCredentialsException;
+import com.hamster.gro_up.exception.auth.*;
 import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.exception.user.UserNotFoundException;
 import com.hamster.gro_up.repository.UserRepository;
 import com.hamster.gro_up.util.JwtUtil;
+import com.hamster.gro_up.util.TokenType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,10 +25,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -36,6 +39,9 @@ class AuthServiceTest {
 
     @Mock
     private EmailVerificationService emailVerificationService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
 
     @Mock
     private PasswordEncoder passwordEncoder;
@@ -66,70 +72,226 @@ class AuthServiceTest {
 
     @Test
     @DisplayName("회원가입에 성공하면 토큰을 반환한다")
-    void signup_success() {
+    void signUp_success() {
         // given
         given(userRepository.existsByEmail(signupRequest.getEmail())).willReturn(false);
         given(passwordEncoder.encode(signupRequest.getPassword())).willReturn("encoded_password");
         given(userRepository.save(any(User.class))).willReturn(user);
-        given(jwtUtil.createToken(anyLong(), anyString(), any(Role.class))).willReturn("token");
+        given(jwtUtil.createToken(eq(TokenType.ACCESS), anyLong(), anyString(), any(Role.class))).willReturn("Access Token");
+        given(jwtUtil.createToken(eq(TokenType.REFRESH), anyLong(), anyString(), any(Role.class))).willReturn("Refresh Token");
         given(emailVerificationService.isEmailVerified(signupRequest.getEmail())).willReturn(true);
 
         // when
-        TokenResponse response = authService.signup(signupRequest);
+        TokenResponse response = authService.signUp(signupRequest);
 
         // then
-        assertThat(response.getToken()).isEqualTo("token");
+        assertThat(response.getAccessToken()).isEqualTo("Access Token");
+        assertThat(response.getRefreshToken()).isEqualTo("Refresh Token");
     }
 
     @Test
     @DisplayName("중복된 이메일로 회원가입 시 예외가 발생한다")
-    void signup_fail_duplicatedEmail() {
+    void signUp_fail_duplicatedEmail() {
         // given
         String duplicatedEmail = "test@example.com";
         given(userRepository.existsByEmail(duplicatedEmail)).willReturn(true);
 
         // when & then
-        DuplicateUserException exception = assertThrows(DuplicateUserException.class, () -> authService.signup(signupRequest));
+        DuplicateUserException exception = assertThrows(DuplicateUserException.class, () -> authService.signUp(signupRequest));
         assertThat(exception.getMessage()).isEqualTo("중복된 사용자가 존재합니다.");
     }
 
 
     @Test
     @DisplayName("로그인에 성공하면 토큰을 반환한다")
-    void signin_success() {
+    void signIn_success() {
         // given
         given(userRepository.findByEmail(signinRequest.getEmail())).willReturn(Optional.of(user));
         given(passwordEncoder.matches(signinRequest.getPassword(), user.getPassword())).willReturn(true);
-        given(jwtUtil.createToken(anyLong(), anyString(), any(Role.class))).willReturn("token");
+        given(jwtUtil.createToken(eq(TokenType.ACCESS), anyLong(), anyString(), any(Role.class))).willReturn("Access Token");
+        given(jwtUtil.createToken(eq(TokenType.REFRESH), anyLong(), anyString(), any(Role.class))).willReturn("Refresh Token");
 
         // when
-        TokenResponse response = authService.signin(signinRequest);
+        TokenResponse response = authService.signIn(signinRequest);
 
         // then
-        assertThat(response.getToken()).isEqualTo("token");
+        assertThat(response.getAccessToken()).isEqualTo("Access Token");
+        assertThat(response.getRefreshToken()).isEqualTo("Refresh Token");
     }
 
     @Test
     @DisplayName("존재하지 않는 이메일로 로그인 시 예외가 발생한다")
-    void signin_fail_userNotFound() {
+    void signIn_fail_userNotFound() {
         // given
         SigninRequest request = new SigninRequest("notfound@example.com", "test");
         given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.empty());
 
         // when & then
-        UserNotFoundException exception = assertThrows(UserNotFoundException.class, () -> authService.signin(request));
+        UserNotFoundException exception = assertThrows(UserNotFoundException.class, () -> authService.signIn(request));
         assertThat(exception.getMessage()).isEqualTo("해당 사용자를 찾을 수 없습니다.");
     }
 
     @Test
     @DisplayName("비밀번호가 일치하지 않을 시 예외가 발생한다")
-    void signin_fail_invalidPassword() {
+    void signIn_fail_invalidPassword() {
         // given
         SigninRequest request = new SigninRequest("test@example.com", "wrongPassword");
         given(userRepository.findByEmail(request.getEmail())).willReturn(Optional.of(user));
 
         // when & then
-        InvalidCredentialsException exception = assertThrows(InvalidCredentialsException.class, () -> authService.signin(request));
+        InvalidCredentialsException exception = assertThrows(InvalidCredentialsException.class, () -> authService.signIn(request));
         assertThat(exception.getMessage()).isEqualTo("이메일 또는 비밀번호가 일치하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("정상적인 Refresh Token 으로 로그아웃에 성공하면 토큰이 삭제된다")
+    void signOut_success() {
+        // given
+        String refreshToken = "validRefreshToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.REFRESH.name());
+        given(jwtUtil.getEmail(refreshToken)).willReturn("test@example.com");
+        given(refreshTokenService.existsByEmail("test@example.com")).willReturn(true);
+
+        // when
+        authService.signOut(refreshToken);
+
+        // then
+        verify(refreshTokenService).deleteRefreshToken("test@example.com");
+    }
+
+    @Test
+    @DisplayName("만료된 Refresh Token 으로 로그아웃 시 예외가 발생한다")
+    void signOut_fail_expiredToken() {
+        // given
+        String refreshToken = "expiredRefreshToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(true);
+
+        // when & then
+        assertThrows(ExpiredTokenException.class, () -> authService.signOut(refreshToken));
+    }
+
+    @Test
+    @DisplayName("Refresh 타입이 아닌 토큰으로 로그아웃 시 예외가 발생한다")
+    void signOut_fail_invalidTokenType() {
+        // given
+        String refreshToken = "accessToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.ACCESS.name());
+
+        // when & then
+        assertThrows(InvalidTokenException.class, () -> authService.signOut(refreshToken));
+    }
+
+    @Test
+    @DisplayName("이미 로그아웃된 사용자(토큰 없음)로 로그아웃 시 예외가 발생한다")
+    void signOut_fail_alreadyLoggedOut() {
+        // given
+        String refreshToken = "validRefreshToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.REFRESH.name());
+        given(jwtUtil.getEmail(refreshToken)).willReturn("test@example.com");
+        given(refreshTokenService.existsByEmail("test@example.com")).willReturn(false);
+
+        // when & then
+        assertThrows(InvalidTokenException.class, () -> authService.signOut(refreshToken));
+    }
+
+    @Test
+    @DisplayName("정상적인 Refresh Token 으로 Access Token 재발급에 성공한다")
+    void reissueAccessToken_success() {
+        // given
+        String refreshToken = "validRefreshToken";
+        AuthUser authUser = mock(AuthUser.class);
+        String email = "test@example.com";
+        String newAccessToken = "newAccessToken";
+        String newRefreshToken = "newRefreshToken";
+
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.REFRESH.name());
+        given(jwtUtil.getAuthUserFromToken(refreshToken)).willReturn(authUser);
+        given(authUser.getEmail()).willReturn(email);
+        given(refreshTokenService.getRefreshToken(email)).willReturn(refreshToken);
+        given(authUser.getId()).willReturn(1L);
+        given(authUser.getRole()).willReturn(Role.ROLE_USER);
+        given(jwtUtil.createToken(eq(TokenType.ACCESS), anyLong(), anyString(), any(Role.class))).willReturn(newAccessToken);
+        given(jwtUtil.createToken(eq(TokenType.REFRESH), anyLong(), anyString(), any(Role.class))).willReturn(newRefreshToken);
+
+        // when
+        TokenResponse response = authService.reissueAccessToken(refreshToken);
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(response.getRefreshToken()).isEqualTo(newRefreshToken);
+        verify(refreshTokenService).deleteRefreshToken(email);
+        verify(refreshTokenService).saveRefreshToken(newRefreshToken, email);
+    }
+
+    @Test
+    @DisplayName("Refresh Token이 null이면 예외가 발생한다")
+    void reissueAccessToken_fail_nullToken() {
+        // when & then
+        assertThrows(InvalidTokenException.class, () -> authService.reissueAccessToken(null));
+    }
+
+    @Test
+    @DisplayName("만료된 Refresh Token 으로 재발급 시 예외가 발생한다")
+    void reissueAccessToken_fail_expiredToken() {
+        // given
+        String refreshToken = "expiredRefreshToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(true);
+
+        // when & then
+        assertThrows(ExpiredTokenException.class, () -> authService.reissueAccessToken(refreshToken));
+    }
+
+    @Test
+    @DisplayName("Refresh 타입이 아닌 토큰으로 재발급 시 예외가 발생한다")
+    void reissueAccessToken_fail_invalidTokenType() {
+        // given
+        String refreshToken = "accessToken";
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.ACCESS.name());
+
+        // when & then
+        assertThrows(TokenTypeMismatchException.class, () -> authService.reissueAccessToken(refreshToken));
+    }
+
+    @Test
+    @DisplayName("저장된 Refresh Token 이 없으면 예외가 발생한다")
+    void reissueAccessToken_fail_tokenNotFound() {
+        // given
+        String refreshToken = "validRefreshToken";
+        AuthUser authUser = mock(AuthUser.class);
+        String email = "test@example.com";
+
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.REFRESH.name());
+        given(jwtUtil.getAuthUserFromToken(refreshToken)).willReturn(authUser);
+        given(authUser.getEmail()).willReturn(email);
+        given(refreshTokenService.getRefreshToken(email)).willReturn(null);
+
+        // when & then
+        assertThrows(TokenNotFoundException.class, () -> authService.reissueAccessToken(refreshToken));
+    }
+
+    @Test
+    @DisplayName("저장된 Refresh Token 과 요청값이 다르면 예외가 발생한다")
+    void reissueAccessToken_fail_tokenMismatch() {
+        // given
+        String refreshToken = "requestToken";
+        String storedToken = "storedToken";
+        AuthUser authUser = mock(AuthUser.class);
+        String email = "test@example.com";
+
+        given(jwtUtil.isExpired(refreshToken)).willReturn(false);
+        given(jwtUtil.getTokenType(refreshToken)).willReturn(TokenType.REFRESH.name());
+        given(jwtUtil.getAuthUserFromToken(refreshToken)).willReturn(authUser);
+        given(authUser.getEmail()).willReturn(email);
+        given(refreshTokenService.getRefreshToken(email)).willReturn(storedToken);
+
+        // when & then
+        InvalidTokenException exception = assertThrows(InvalidTokenException.class, () -> authService.reissueAccessToken(refreshToken));
+        assertThat(exception.getMessage()).isEqualTo("Refresh Token 이 일치하지 않습니다.");
     }
 }

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -60,7 +60,7 @@ class CompanyServiceTest {
                 .url("www.ham.com")
                 .build();
 
-        authUser = new AuthUser(1L, "ham@gmail.com", Role.ROLE_USER);
+        authUser = AuthUser.builder().id(1L).email("ham@gmail.com").role(Role.ROLE_USER).build();
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
* JWT 기반 인증 시스템에서 Refresh Token 기능을 신규로 구현하였습니다.

## 작업 상세
* Refresh Token 발급 및 저장 로직 추가 (회원가입/로그인 시)
* Redis를 활용한 Refresh Token 저장 및 만료 관리
* Refresh Token Rotation(RTR) 적용: Access Token 재발급 시 Refresh Token도 함께 갱신
* 로그아웃 시 Refresh Token 삭제 및 쿠키 만료 처리
* Refresh Token을 활용한 Access Token 재발급 API 구현
* Refresh Token 관련 예외 처리 및 응답 포맷 통일(ApiResponse 적용)
* 테스트 코드 추가(MockMvc, Service 단위 테스트 등)
* Swagger API 명세 업데이트

## 관련 이슈
This closes #9 