### PR TITLE
fix: 바인드 마운트 방식에서 도커 볼륨 마운트 방식으로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./prometheus-data:/prometheus
+      - prometheus-data:/prometheus
     networks:
       - backend
 
@@ -45,7 +45,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./grafana-data:/var/lib/grafana
+      - grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
     networks:
@@ -53,3 +53,7 @@ services:
 
 networks:
   backend:
+
+volumes:
+  prometheus-data:
+  grafana-data:


### PR DESCRIPTION
## 작업 내용
권한 문제의 해결을 위해서 Prometheus 와 Grafana 의 데이터 관리를 바인드 마운트 방식에서 도커 볼륨 마운트 방식으로 변경하였습니다.

## 관련 이슈
This closes #80
