### PR TITLE
feat: 비밀번호 검증, 변경, 재설정 API 구현

### DIFF
--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.hamster.gro_up.controller;
 
 import com.hamster.gro_up.dto.ApiResponse;
 import com.hamster.gro_up.dto.AuthUser;
+import com.hamster.gro_up.dto.request.PasswordCheckRequest;
+import com.hamster.gro_up.dto.request.PasswordUpdateRequest;
 import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
@@ -101,6 +103,37 @@ public class AuthController {
     @DeleteMapping("/account")
     public ResponseEntity<ApiResponse<Void>> deleteAccount(@AuthenticationPrincipal AuthUser authUser) {
         authService.deleteAccount(authUser);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "비밀번호 검증")
+    @PostMapping("/password-check")
+    public ResponseEntity<ApiResponse<Void>> checkPassword(@AuthenticationPrincipal AuthUser authUser,
+                                                           @Valid @RequestBody PasswordCheckRequest passwordCheckRequest) {
+        authService.checkPassword(authUser, passwordCheckRequest);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @PostMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(@AuthenticationPrincipal AuthUser authUser,
+                                                            @Valid @RequestBody PasswordUpdateRequest passwordUpdateRequest) {
+        authService.updatePassword(authUser, passwordUpdateRequest);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "비밀번호 재설정 요청")
+    @PostMapping("/reset-request")
+    public ResponseEntity<ApiResponse<Void>> resetRequest(@RequestParam String email) {
+        authService.requestPasswordReset(email);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "비밀번호 재설정")
+    @PostMapping("/reset-password")
+    public ResponseEntity<ApiResponse<Void>> reset(@RequestParam String token,
+                                                   @Valid @RequestBody PasswordUpdateRequest passwordUpdateRequest) {
+        authService.resetPassword(token, passwordUpdateRequest);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/hamster/gro_up/dto/request/PasswordCheckRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/PasswordCheckRequest.java
@@ -1,0 +1,14 @@
+package com.hamster.gro_up.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PasswordCheckRequest {
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/hamster/gro_up/dto/request/PasswordUpdateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.hamster.gro_up.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class PasswordUpdateRequest {
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/hamster/gro_up/entity/User.java
+++ b/src/main/java/com/hamster/gro_up/entity/User.java
@@ -28,4 +28,8 @@ public class User extends BaseEntity {
         this.password = password;
         this.role = role;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -1,14 +1,16 @@
 package com.hamster.gro_up.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hamster.gro_up.advise.GlobalExceptionHandler;
 import com.hamster.gro_up.config.*;
 import com.hamster.gro_up.dto.AuthUser;
+import com.hamster.gro_up.dto.request.PasswordCheckRequest;
+import com.hamster.gro_up.dto.request.PasswordUpdateRequest;
 import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
 import com.hamster.gro_up.exception.auth.ExpiredTokenException;
+import com.hamster.gro_up.exception.auth.InvalidCredentialsException;
 import com.hamster.gro_up.exception.auth.InvalidEmailVerificationTokenException;
 import com.hamster.gro_up.exception.auth.TokenTypeMismatchException;
 import com.hamster.gro_up.exception.user.DuplicateUserException;
@@ -29,10 +31,10 @@ import org.springframework.mock.web.MockCookie;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -76,8 +78,7 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signupRequest))
-                        .with(csrf()))
+                        .content(objectMapper.writeValueAsString(signupRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -96,8 +97,7 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/signin")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(signinRequest))
-                        .with(csrf()))
+                        .content(objectMapper.writeValueAsString(signinRequest)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -130,8 +130,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/email/verify-request")
-                        .param("email", email)
-                        .with(csrf()))
+                        .param("email", email))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -148,8 +147,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/email/verify-request")
-                        .param("email", email)
-                        .with(csrf()))
+                        .param("email", email))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."));
@@ -165,8 +163,7 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/email/verify-check")
                         .param("email", email)
-                        .param("code", code)
-                        .with(csrf()))
+                        .param("code", code))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -185,8 +182,7 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/email/verify-check")
                         .param("email", email)
-                        .param("code", code)
-                        .with(csrf()))
+                        .param("code", code))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("인증 코드가 유효하지 않습니다."));
@@ -204,8 +200,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/logout")
-                        .cookie(refreshCookie)
-                        .with(csrf()))
+                        .cookie(refreshCookie))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -220,8 +215,7 @@ class AuthControllerTest {
     @DisplayName("Refresh Token 이 없으면 로그아웃 시 400 을 반환한다")
     void logout_fail_noRefreshToken() throws Exception {
         // when & then
-        mockMvc.perform(post("/api/auth/logout")
-                        .with(csrf()))
+        mockMvc.perform(post("/api/auth/logout"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Refresh Token 이 존재하지 않습니다."));
@@ -242,8 +236,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/reissue")
-                        .cookie(refreshCookie)
-                        .with(csrf()))
+                        .cookie(refreshCookie))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -256,8 +249,7 @@ class AuthControllerTest {
     @DisplayName("Refresh Token 이 없으면 토큰 재발급 시 400 을 반환한다")
     void reissue_fail_noRefreshToken() throws Exception {
         // when & then
-        mockMvc.perform(post("/api/auth/reissue")
-                        .with(csrf()))
+        mockMvc.perform(post("/api/auth/reissue"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("Refresh Token 이 존재하지 않습니다."));
@@ -273,8 +265,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/logout")
-                        .cookie(refreshCookie)
-                        .with(csrf()))
+                        .cookie(refreshCookie))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(401))
                 .andExpect(jsonPath("$.message").value("만료된 토큰입니다."));
@@ -290,8 +281,7 @@ class AuthControllerTest {
 
         // when & then
         mockMvc.perform(post("/api/auth/logout")
-                        .cookie(refreshCookie)
-                        .with(csrf()))
+                        .cookie(refreshCookie))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(401))
                 .andExpect(jsonPath("$.message").value("Token type 이 일치하지 않습니다."));
@@ -322,5 +312,127 @@ class AuthControllerTest {
         mockMvc.perform(delete("/api/auth/account"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404));
+    }
+
+    @Test
+    @DisplayName("비밀번호 검증에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
+    void checkPassword_success() throws Exception {
+        // given
+        PasswordCheckRequest request = new PasswordCheckRequest("password123");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/password-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).checkPassword(any(AuthUser.class), any(PasswordCheckRequest.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 올바르지 않으면 401을 반환한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
+    void checkPassword_fail_wrongPassword() throws Exception {
+        // given
+        PasswordCheckRequest request = new PasswordCheckRequest("wrongPassword");
+        doThrow(new InvalidCredentialsException()).when(authService).checkPassword(any(AuthUser.class), any(PasswordCheckRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/password-check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
+    void updatePassword_success() throws Exception {
+        // given
+        PasswordUpdateRequest request = new PasswordUpdateRequest("new password");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).updatePassword(any(AuthUser.class), any(PasswordUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 요청에 성공한다")
+    void resetRequest_success() throws Exception {
+        // given
+        String email = "ham@example.com";
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-request")
+                        .param("email", email))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).requestPasswordReset(email);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 재설정 요청 시 404를 반환한다")
+    void resetRequest_fail_emailNotFound() throws Exception {
+        // given
+        String email = "notfound@example.com";
+        doThrow(new UserNotFoundException()).when(authService).requestPasswordReset(email);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-request")
+                        .param("email", email))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404));
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정에 성공한다")
+    void reset_success() throws Exception {
+        // given
+        String token = "reset-token";
+        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-password")
+                        .param("token", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).resetPassword(eq(token), any(PasswordUpdateRequest.class));
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 비밀번호 재설정 시 401을 반환한다")
+    void reset_fail_expiredToken() throws Exception {
+        // given
+        String token = "expired-token";
+        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+        doThrow(new ExpiredTokenException()).when(authService).resetPassword(eq(token), any(PasswordUpdateRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-password")
+                        .param("token", token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401));
     }
 }


### PR DESCRIPTION
## 작업 내용
비밀번호 검증, 변경, 재설정 API 구현 및 테스트 코드 작성을 하였습니다.

## 작업 상세
* 로그인 한 상태에서 비밀번호를 변경하기 위해선 비밀먼호 검증을 우선 해야합니다.
* 비밀번호를 잊어 재설정을 해야하는 경우에는 이메일로 `비밀번호 재설정 url` 을 안내받은 후 해당 url 로 이동하여 비밀번호 재설정을 해야합니다.

## 참고 사항
현재 프론트의 배포가 완료되지 않았기에 `비밀번호 재설정 url` 을 임시로 채워 놓았습니다.

## 관련 이슈
This closes #83 
