### PR TITLE
feat: 날짜 범위 기반 조회 API 구현

### DIFF
--- a/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
+++ b/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
@@ -11,10 +11,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Tag(name = "일정", description = "일정 관련 API")
 @RequiredArgsConstructor
@@ -60,5 +64,16 @@ public class ScheduleController {
     public ResponseEntity<ApiResponse<Void>> deleteSchedule(@AuthenticationPrincipal AuthUser authUser, @PathVariable Long scheduleId) {
         scheduleService.deleteSchedule(authUser, scheduleId);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "날짜 범위별 일정 조회")
+    @GetMapping("/range")
+    public ResponseEntity<ApiResponse<ScheduleListResponse>> getSchedulesByDateRange(
+            @AuthenticationPrincipal AuthUser authUser,
+            @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate start,
+            @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate end
+    ) {
+        ScheduleListResponse response = scheduleService.findSchedulesInRange(authUser, start, end);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/hamster/gro_up/dto/ApiResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/ApiResponse.java
@@ -8,28 +8,28 @@ public class ApiResponse<T> {
 
     private int code;
     private HttpStatus status;
-    private String message;
+    private Object message;
     private T data;
 
-    public ApiResponse(int code, HttpStatus status, String message, T data) {
+    public ApiResponse(int code, HttpStatus status, Object message, T data) {
         this.code = code;
         this.status = status;
         this.message = message;
         this.data = data;
     }
 
-    public ApiResponse(HttpStatus status, String message, T data) {
+    public ApiResponse(HttpStatus status, Object message, T data) {
         this.code = status.value();
         this.status = status;
         this.data = data;
         this.message = message;
     }
 
-    public static <T> ApiResponse<T> of(int code, HttpStatus status, String message, T data) {
+    public static <T> ApiResponse<T> of(int code, HttpStatus status, Object message, T data) {
         return new ApiResponse<>(code, status, message, data);
     }
 
-    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, Object message, T data) {
         return new ApiResponse<>(httpStatus, message, data);
     }
 

--- a/src/main/java/com/hamster/gro_up/repository/ScheduleRepository.java
+++ b/src/main/java/com/hamster/gro_up/repository/ScheduleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +15,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("select s from Schedule s join fetch s.company where s.user.id = :userId")
     List<Schedule> findByUserIdWithCompany(@Param("userId") Long userId);
+
+    @Query("SELECT s FROM Schedule s " +
+           "WHERE s.user.id = :userId " +
+           "AND s.dueDate BETWEEN :start AND :end " +
+           "ORDER BY s.dueDate ASC")
+    List<Schedule> findSchedulesInRange(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 }

--- a/src/main/java/com/hamster/gro_up/service/ScheduleService.java
+++ b/src/main/java/com/hamster/gro_up/service/ScheduleService.java
@@ -18,6 +18,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -99,5 +102,16 @@ public class ScheduleService {
         schedule.validateOwner(authUser.getId());
 
         scheduleRepository.delete(schedule);
+    }
+
+    public ScheduleListResponse findSchedulesInRange(AuthUser authUser, LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+
+        List<Schedule> schedules = scheduleRepository.findSchedulesInRange(authUser.getId(), startDateTime, endDateTime);
+
+        List<ScheduleResponse> responseList = schedules.stream().map(ScheduleResponse::from).toList();
+
+        return ScheduleListResponse.of(responseList);
     }
 }


### PR DESCRIPTION
## 작업 내용
날짜 범위 기반 조회 API 의 구현 및 테스트 코드 작성을 하였습니다.

## 작업 상세
* 공통 응답 DTO `message` 타입 `String` -> `Object` 로 변경
* `MissingServletRequestParameterException` 예외 처리 추가