### PR TITLE
release: develop -> main (일정 생성 시 기업의 위치도 받을 수 있도록 구현)

### DIFF
--- a/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
@@ -16,6 +16,8 @@ public class ScheduleCreateRequest {
     @NotBlank
     private String companyName;
 
+    private String companyLocation;
+
     private Step step;
 
     private LocalDateTime dueDate;

--- a/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
@@ -14,6 +14,8 @@ public class ScheduleResponse {
 
     private String companyName;
 
+    private String companyLocation;
+
     private String step;
 
     private String position;
@@ -32,6 +34,7 @@ public class ScheduleResponse {
         return new ScheduleResponse(
                 companyId,
                 schedule.getCompanyName(),
+                schedule.getCompanyLocation(),
                 schedule.getStep().getDisplayName(),
                 schedule.getPosition(),
                 schedule.getMemo(),

--- a/src/main/java/com/hamster/gro_up/entity/Schedule.java
+++ b/src/main/java/com/hamster/gro_up/entity/Schedule.java
@@ -32,12 +32,14 @@ public class Schedule extends BaseEntity {
 
     private String companyName;
 
+    private String companyLocation;
+
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT), updatable = false, nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     @Builder
-    public Schedule(Long id, Step step, String position, LocalDateTime dueDate, String memo, Company company, String companyName, User user) {
+    public Schedule(Long id, Step step, String position, LocalDateTime dueDate, String memo, Company company, String companyName, String companyLocation, User user) {
         this.id = id;
         this.step = step;
         this.dueDate = dueDate;
@@ -45,6 +47,7 @@ public class Schedule extends BaseEntity {
         this.memo = memo;
         this.company = company;
         this.companyName = companyName;
+        this.companyLocation = companyLocation;
         this.user = user;
     }
 

--- a/src/main/java/com/hamster/gro_up/service/ScheduleService.java
+++ b/src/main/java/com/hamster/gro_up/service/ScheduleService.java
@@ -52,6 +52,7 @@ public class ScheduleService {
     public ScheduleResponse createSchedule(AuthUser authUser, ScheduleCreateRequest request) {
         Company company = null;
         String companyName;
+        String companyLocation;
 
         if(request.getCompanyId() != null) {
             company = companyRepository.findById(request.getCompanyId())
@@ -60,8 +61,10 @@ public class ScheduleService {
             company.validateOwner(authUser.getId());
 
             companyName = company.getCompanyName();
+            companyLocation = company.getLocation();
         }else {
             companyName = request.getCompanyName();
+            companyLocation = request.getCompanyLocation();
         }
 
         User user = userRepository.findById(authUser.getId()).orElseThrow(UserNotFoundException::new);
@@ -70,6 +73,7 @@ public class ScheduleService {
                 .user(user)
                 .company(company)
                 .companyName(companyName)
+                .companyLocation(companyLocation)
                 .dueDate(request.getDueDate())
                 .step(request.getStep())
                 .position(request.getPosition())

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -65,7 +65,7 @@ class ScheduleControllerTest {
         // given
         ScheduleResponse response = new ScheduleResponse(
                 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
-                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         given(scheduleService.findSchedule(any(), eq(100L))).willReturn(response);
 
@@ -100,11 +100,11 @@ class ScheduleControllerTest {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
                 10L, "ham-corp", "DOCUMENT", "백엔드", "메모1",
-                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
                 11L, "egg-corp", "INTERVIEW", "프론트엔드", "메모2",
-                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));
         given(scheduleService.findAllSchedules(any())).willReturn(response);
@@ -126,11 +126,11 @@ class ScheduleControllerTest {
     void createSchedule_success() throws Exception {
         // given
         ScheduleCreateRequest request = new ScheduleCreateRequest(
-                10L, "ham-corp", Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
+                10L, "ham-corp", "서울", Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
         );
         ScheduleResponse response = new ScheduleResponse(
                 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
-                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         given(scheduleService.createSchedule(any(), any())).willReturn(response);
 
@@ -198,6 +198,7 @@ class ScheduleControllerTest {
         ScheduleCreateRequest invalidRequest = new ScheduleCreateRequest(
                 null,           // companyId
                 "",             // companyName (NotBlank 위반)
+                "서울",
                 null,           // step
                 null,           // dueDate
                 null,           // position
@@ -221,13 +222,13 @@ class ScheduleControllerTest {
     void getSchedulesByDateRange_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
-                1L, "ham-corp", "DOCUMENT", "백엔드", "메모",
+                1L, "ham-corp", "서울", "DOCUMENT", "백엔드", "메모",
                 LocalDateTime.of(2025, 5, 10, 10, 0),
                 LocalDateTime.of(2025, 5, 10, 11, 0),
                 LocalDateTime.of(2025, 5, 10, 10, 0)
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                2L, "ham-corp", "INTERVIEW", "프론트", "면접",
+                2L, "ham-corp", "서울", "INTERVIEW", "프론트", "면접",
                 LocalDateTime.of(2025, 5, 20, 14, 0),
                 LocalDateTime.of(2025, 5, 20, 15, 0),
                 LocalDateTime.of(2025, 5, 20, 14, 0)

--- a/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
@@ -168,6 +168,7 @@ class ScheduleServiceTest {
         ScheduleCreateRequest request = new ScheduleCreateRequest(
                 company.getId(),
                 company.getCompanyName(),
+                company.getLocation(),
                 schedule.getStep(),
                 schedule.getDueDate(),
                 schedule.getPosition(),
@@ -197,6 +198,7 @@ class ScheduleServiceTest {
         ScheduleCreateRequest request = new ScheduleCreateRequest(
                 company.getId(),
                 company.getCompanyName(),
+                company.getLocation(),
                 schedule.getStep(),
                 schedule.getDueDate(),
                 schedule.getPosition(),


### PR DESCRIPTION
## 작업 내용
일정 생성 시 기업의 위치도 따로 받을 수 있도록 구현하였습니다.
기업의 `id` 가 `null` 이 아닐 시 따로 받은 위치가 아닌, 해당 `id`의 기업의 위치를 가져와서 저장합니다.