### PR TITLE
feat: 기업명으로 일정 검색 기능 구현(복합 인덱스)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ gradle-app.setting
 
 src/main/resources/application-prod.yml
 develop/docker-compose.yml
+/develop/

--- a/src/main/java/com/hamster/gro_up/controller/CompanyController.java
+++ b/src/main/java/com/hamster/gro_up/controller/CompanyController.java
@@ -5,6 +5,7 @@ import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
 import com.hamster.gro_up.dto.response.CompanyListResponse;
+import com.hamster.gro_up.dto.response.CompanyNameListResponse;
 import com.hamster.gro_up.dto.response.CompanyResponse;
 import com.hamster.gro_up.service.CompanyService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,5 +61,12 @@ public class CompanyController {
                                                            @PathVariable Long companyId) {
         companyService.deleteCompany(authUser, companyId);
         return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "모든 기업명 조회")
+    @GetMapping("/names")
+    public ResponseEntity<ApiResponse<CompanyNameListResponse>> findAllCompanyNames(@AuthenticationPrincipal AuthUser authUser) {
+        CompanyNameListResponse response = companyService.findAllCompanyNames(authUser);
+        return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
+++ b/src/main/java/com/hamster/gro_up/controller/ScheduleController.java
@@ -68,12 +68,20 @@ public class ScheduleController {
 
     @Operation(summary = "날짜 범위별 일정 조회")
     @GetMapping("/range")
-    public ResponseEntity<ApiResponse<ScheduleListResponse>> getSchedulesByDateRange(
+    public ResponseEntity<ApiResponse<ScheduleListResponse>> findSchedulesByDateRange(
             @AuthenticationPrincipal AuthUser authUser,
             @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate start,
             @RequestParam @DateTimeFormat(pattern = "yyyyMMdd") LocalDate end
     ) {
         ScheduleListResponse response = scheduleService.findSchedulesInRange(authUser, start, end);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "정확한 기업명으로 일정 검색")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<ScheduleListResponse>> findSchedulesByCompanyName(
+            @AuthenticationPrincipal AuthUser authUser, @RequestParam String companyName) {
+        ScheduleListResponse response = scheduleService.findSchedulesByCompanyName(authUser, companyName);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/hamster/gro_up/dto/response/CompanyNameListResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/CompanyNameListResponse.java
@@ -1,0 +1,16 @@
+package com.hamster.gro_up.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Getter
+public class CompanyNameListResponse {
+    private List<String> companyNameList;
+
+    public static CompanyNameListResponse of(List<String> companyNameList) {
+        return new CompanyNameListResponse(companyNameList);
+    }
+}

--- a/src/main/java/com/hamster/gro_up/repository/CompanyRepository.java
+++ b/src/main/java/com/hamster/gro_up/repository/CompanyRepository.java
@@ -2,9 +2,16 @@ package com.hamster.gro_up.repository;
 
 import com.hamster.gro_up.entity.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
     List<Company> findByUserId(Long userId);
+
+    @Query(value = "SELECT company_name FROM company WHERE user_id = :userId " +
+                   "UNION " +
+                   "SELECT company_name FROM schedule WHERE user_id = :userId", nativeQuery = true)
+    List<String> findAllCompanyNamesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -128,10 +128,6 @@ public class AuthService {
             throw new TokenNotFoundException();
         }
 
-        log.info("storedRefreshToken: {}", storedRefreshToken);
-        log.info("refreshToken from request: {}", refreshToken);
-        log.info("equals: {}", storedRefreshToken.equals(refreshToken));
-
         if (!storedRefreshToken.equals(refreshToken)) {
             throw new InvalidTokenException("Refresh Token 이 일치하지 않습니다.");
         }

--- a/src/main/java/com/hamster/gro_up/service/CompanyService.java
+++ b/src/main/java/com/hamster/gro_up/service/CompanyService.java
@@ -4,6 +4,7 @@ import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
 import com.hamster.gro_up.dto.response.CompanyListResponse;
+import com.hamster.gro_up.dto.response.CompanyNameListResponse;
 import com.hamster.gro_up.dto.response.CompanyResponse;
 import com.hamster.gro_up.entity.Company;
 import com.hamster.gro_up.entity.User;
@@ -78,5 +79,10 @@ public class CompanyService {
         company.validateOwner(authUser.getId());
 
         companyRepository.delete(company);
+    }
+
+    public CompanyNameListResponse findAllCompanyNames(AuthUser authUser) {
+        List<String> companyNames = companyRepository.findAllCompanyNamesByUserId(authUser.getId());
+        return CompanyNameListResponse.of(companyNames);
     }
 }

--- a/src/main/java/com/hamster/gro_up/service/ScheduleService.java
+++ b/src/main/java/com/hamster/gro_up/service/ScheduleService.java
@@ -118,4 +118,12 @@ public class ScheduleService {
 
         return ScheduleListResponse.of(responseList);
     }
+
+    public ScheduleListResponse findSchedulesByCompanyName(AuthUser authUser, String companyName) {
+        List<Schedule> schedules = scheduleRepository.findByUserIdAndCompanyName(authUser.getId(), companyName);
+
+        List<ScheduleResponse> responseList = schedules.stream().map(ScheduleResponse::from).toList();
+
+        return ScheduleListResponse.of(responseList);
+    }
 }

--- a/src/main/resources/db/migration/V9__add_index_on_schedule_user_id_and_company_name.sql
+++ b/src/main/resources/db/migration/V9__add_index_on_schedule_user_id_and_company_name.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_schedule_user_company ON schedule (user_id, company_name);

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -5,6 +5,7 @@ import com.hamster.gro_up.config.*;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
 import com.hamster.gro_up.dto.response.CompanyListResponse;
+import com.hamster.gro_up.dto.response.CompanyNameListResponse;
 import com.hamster.gro_up.dto.response.CompanyResponse;
 import com.hamster.gro_up.entity.Role;
 import com.hamster.gro_up.exception.company.CompanyNotFoundException;
@@ -195,5 +196,26 @@ class CompanyControllerTest {
                 .andExpect(jsonPath("$.message").exists())
                 .andExpect(jsonPath("$.message").isNotEmpty())
                 .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("모든 기업명 조회에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
+    void findAllCompanyNames_success() throws Exception {
+        // given
+        List<String> companyNames = List.of("네이버", "카카오", "라인");
+        CompanyNameListResponse response = CompanyNameListResponse.of(companyNames);
+        given(companyService.findAllCompanyNames(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/companies/names"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.companyNameList").isArray())
+                .andExpect(jsonPath("$.data.companyNameList[0]").value("네이버"))
+                .andExpect(jsonPath("$.data.companyNameList[1]").value("카카오"))
+                .andExpect(jsonPath("$.data.companyNameList[2]").value("라인"));
     }
 }

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -286,4 +286,33 @@ class ScheduleControllerTest {
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").exists());
     }
+
+    @Test
+    @DisplayName("정확한 기업명으로 일정 검색에 성공한다")
+    @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
+    void findSchedulesByCompanyName_success() throws Exception {
+        // given
+        String companyName = "네이버";
+        ScheduleResponse schedule1 = new ScheduleResponse(
+                10L, companyName, "서울", "DOCUMENT", "백엔드", "메모1",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        ScheduleResponse schedule2 = new ScheduleResponse(
+                10L, companyName, "서울", "INTERVIEW", "프론트엔드", "메모2",
+                LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+        );
+        ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));
+        given(scheduleService.findSchedulesByCompanyName(any(), eq(companyName))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/schedules/search")
+                        .param("companyName", companyName))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.scheduleList").isArray())
+                .andExpect(jsonPath("$.data.scheduleList[0].companyName").value(companyName))
+                .andExpect(jsonPath("$.data.scheduleList[1].companyName").value(companyName));
+    }
 }

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -4,6 +4,7 @@ import com.hamster.gro_up.dto.AuthUser;
 import com.hamster.gro_up.dto.request.CompanyCreateRequest;
 import com.hamster.gro_up.dto.request.CompanyUpdateRequest;
 import com.hamster.gro_up.dto.response.CompanyListResponse;
+import com.hamster.gro_up.dto.response.CompanyNameListResponse;
 import com.hamster.gro_up.dto.response.CompanyResponse;
 import com.hamster.gro_up.entity.Company;
 import com.hamster.gro_up.entity.Role;
@@ -214,5 +215,21 @@ class CompanyServiceTest {
 
         // then
         assertThat(response.getCompanyList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("유저의 모든 기업명 조회 성공")
+    void findAllCompanyNames_success() {
+        // given
+        List<String> companyNames = List.of("네이버", "카카오", "라인");
+
+        given(companyRepository.findAllCompanyNamesByUserId(authUser.getId())).willReturn(companyNames);
+
+        // when
+        CompanyNameListResponse response = companyService.findAllCompanyNames(authUser);
+
+        // then
+        assertThat(response.getCompanyNameList()).hasSize(3);
+        assertThat(response.getCompanyNameList()).containsExactlyInAnyOrderElementsOf(companyNames);
     }
 }

--- a/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
@@ -323,4 +323,33 @@ class ScheduleServiceTest {
         assertThat(resp2.getDueDate()).isEqualTo(schedule2.getDueDate());
     }
 
+    @Test
+    @DisplayName("회사명으로 일정 조회 성공")
+    void findSchedulesByCompanyName_success() {
+        // given
+        String companyName = "네이버";
+
+        Schedule schedule2 = Schedule.builder()
+                .id(1L)
+                .user(user)
+                .companyName(companyName)
+                .position("개발자")
+                .memo("메모1")
+                .step(Step.DOCUMENT)
+                .dueDate(LocalDateTime.now())
+                .build();
+
+        List<Schedule> schedules = List.of(schedule, schedule2);
+
+        given(scheduleRepository.findByUserIdAndCompanyName(authUser.getId(), companyName)).willReturn(schedules);
+
+        // when
+        ScheduleListResponse response = scheduleService.findSchedulesByCompanyName(authUser, companyName);
+
+        // then
+        assertThat(response.getScheduleList()).hasSize(2);
+        ScheduleResponse scheduleResponse = response.getScheduleList().get(1);
+        assertThat(scheduleResponse.getCompanyName()).isEqualTo(companyName);
+        assertThat(scheduleResponse.getPosition()).isEqualTo(schedule2.getPosition());
+    }
 }


### PR DESCRIPTION
## 작업 내용
* 기업명으로 일정 조회 기능 구현(복합 인덱스) 및 테스트 코드 작성
* 해당 사용자의 모든 기업명 조회 기능 구현 및 테스트 코드 작성

## 작업 상세
조회 속도를 고려하여 `user_id`, `company_name` 복합 인덱스를 적용했습니다. 

### `schedule` 1000만 건 기준(사용자 수=1000, 기업 수=100(사용자 당), 일정 수=100(기업 당))
* `like` 를 사용하여 단어 일부분 검색 허용 : 6s , rows 9,936,479 조회
* 인덱스 없음 : 4s, rows 9,936,479 조회
* `company_name` 단일 인덱스 적용 : 22ms, rows 100 조회, filtered 10 (필터링 후 남는 비율)
* `user_id` , `company_name` 복합 인덱스 적용 : 7ms, rows 100 조회, filtererd 100

## 서비스 검색 기능 로직 참고
`https://crawling-balaur-167.notion.site/1f9bcd15067480479d60e601e9cffad2?pvs=4`

## 관련 이슈
This closes #52 