### PR TITLE
fix: `Refresh Token` 응답 방식 수정

### DIFF
--- a/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
@@ -5,9 +5,12 @@ import com.hamster.gro_up.dto.ApiResponse;
 import com.hamster.gro_up.dto.CustomOAuth2User;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
+import com.hamster.gro_up.entity.UserType;
+import com.hamster.gro_up.util.CookieUtil;
 import com.hamster.gro_up.util.JwtUtil;
 import com.hamster.gro_up.util.TokenType;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -32,13 +35,15 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         Long userId = customOAuth2User.getId();
         String email = customOAuth2User.getAttribute("email");
 
-        String accessToken = jwtUtil.createToken(TokenType.ACCESS, userId, email, Role.ROLE_USER);
-        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, userId, email, Role.ROLE_USER);
+        String accessToken = jwtUtil.createToken(TokenType.ACCESS, UserType.OAUTH, userId, email, Role.ROLE_USER);
+        String refreshToken = jwtUtil.createToken(TokenType.REFRESH, UserType.OAUTH, userId, email, Role.ROLE_USER);
 
-        TokenResponse tokenResponse = TokenResponse.of(accessToken, refreshToken);
+        ApiResponse<String> apiResponse = ApiResponse.of(HttpStatus.OK, accessToken);
 
-        ApiResponse<TokenResponse> apiResponse = ApiResponse.of(HttpStatus.OK, tokenResponse);
+        Cookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(refreshToken);
 
+        // Refresh Token 은 Cookie 에, Access Token 은 Body 에 담음
+        response.addCookie(refreshTokenCookie);
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));

--- a/src/main/java/com/hamster/gro_up/util/CookieUtil.java
+++ b/src/main/java/com/hamster/gro_up/util/CookieUtil.java
@@ -33,4 +33,8 @@ public class CookieUtil {
         cookie.setSecure(true); // 운영환경에서만 true
         return cookie;
     }
+
+    public static Cookie createRefreshTokenCookie(String refreshToken){
+        return CookieUtil.createCookie(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, refreshToken, 60 * 60 * 24 * 14); // 2주
+    }
 }

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -82,8 +82,8 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.data.accessToken").value(token.getAccessToken()))
-                .andExpect(jsonPath("$.data.refreshToken").value(token.getRefreshToken()));
+                .andExpect(jsonPath("$.data").value(token.getAccessToken()))
+                .andExpect(cookie().value(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "Refresh Token"));
     }
 
     @Test
@@ -101,8 +101,8 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.data.accessToken").value(token.getAccessToken()))
-                .andExpect(jsonPath("$.data.refreshToken").value(token.getRefreshToken()));
+                .andExpect(jsonPath("$.data").value(token.getAccessToken()))
+                .andExpect(cookie().value(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "Refresh Token"));
     }
 
     @Test
@@ -240,8 +240,7 @@ class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
-                .andExpect(jsonPath("$.data.refreshToken").value("newRefreshToken"))
+                .andExpect(jsonPath("$.data").value("newAccessToken"))
                 .andExpect(cookie().value(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "newRefreshToken"));
     }
 


### PR DESCRIPTION
## 작업 내용
`Access Token` 과 `Refresh Token` 을 `body` 에 몽땅 담고, 정작 쿠키를 반환하지 않았기에
인증 완료 시 `body` 에는 `Access Token` 만 담고, `Refresh Token` 은 쿠키에 담아서 응답하도록 수정했습니다.

## 관련 이슈
This closes #96 