### PR TITLE
feat: 비밀번호 재설정 로직 변경

### DIFF
--- a/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
+++ b/src/main/java/com/hamster/gro_up/advise/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package com.hamster.gro_up.advise;
 
 import com.hamster.gro_up.dto.ApiResponse;
-import com.hamster.gro_up.exception.BadRequestException;
-import com.hamster.gro_up.exception.ForbiddenException;
-import com.hamster.gro_up.exception.NotFoundException;
-import com.hamster.gro_up.exception.UnauthorizedException;
+import com.hamster.gro_up.exception.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -53,6 +50,15 @@ public class GlobalExceptionHandler {
         log.error(e.getMessage());
 
         HttpStatus status = HttpStatus.NOT_FOUND;
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConflictException(ConflictException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.CONFLICT; // 409
 
         return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
     }

--- a/src/main/java/com/hamster/gro_up/controller/AuthController.java
+++ b/src/main/java/com/hamster/gro_up/controller/AuthController.java
@@ -116,7 +116,7 @@ public class AuthController {
     }
 
     @Operation(summary = "비밀번호 검증")
-    @PostMapping("/password-check")
+    @PostMapping("/check-password")
     public ResponseEntity<ApiResponse<Void>> checkPassword(@AuthenticationPrincipal AuthUser authUser,
                                                            @Valid @RequestBody PasswordCheckRequest passwordCheckRequest) {
         authService.checkPassword(authUser, passwordCheckRequest);
@@ -140,9 +140,16 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 재설정")
     @PostMapping("/reset-password")
-    public ResponseEntity<ApiResponse<Void>> reset(@RequestParam String token,
+    public ResponseEntity<ApiResponse<Void>> reset(@RequestParam String email,
                                                    @Valid @RequestBody PasswordUpdateRequest passwordUpdateRequest) {
-        authService.resetPassword(token, passwordUpdateRequest);
+        authService.resetPasswordWithEmail(email, passwordUpdateRequest);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "이메일 중복 검사")
+    @GetMapping("/check-email")
+    public ResponseEntity<ApiResponse<Void>> checkEmailDuplicate(@RequestParam String email) {
+        authService.checkEmailDuplicate(email);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 }

--- a/src/main/java/com/hamster/gro_up/exception/ConflictException.java
+++ b/src/main/java/com/hamster/gro_up/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.hamster.gro_up.exception;
+
+public class ConflictException extends RuntimeException{
+    private static final String MESSAGE = "현재 리소스의 상태와 충돌합니다.";
+
+    public ConflictException() {super(MESSAGE);}
+
+    public ConflictException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/auth/PasswordChangeNotAllowedException.java
+++ b/src/main/java/com/hamster/gro_up/exception/auth/PasswordChangeNotAllowedException.java
@@ -1,0 +1,11 @@
+package com.hamster.gro_up.exception.auth;
+
+import com.hamster.gro_up.exception.ForbiddenException;
+
+public class PasswordChangeNotAllowedException extends ForbiddenException {
+    private static final String MESSAGE = "비밀번호 변경이 허용되지 않는 사용자입니다.";
+
+    public PasswordChangeNotAllowedException() {super(MESSAGE);}
+
+    public PasswordChangeNotAllowedException(String message) {super(message);}
+}

--- a/src/main/java/com/hamster/gro_up/exception/user/DuplicateUserException.java
+++ b/src/main/java/com/hamster/gro_up/exception/user/DuplicateUserException.java
@@ -1,8 +1,8 @@
 package com.hamster.gro_up.exception.user;
 
-import com.hamster.gro_up.exception.BadRequestException;
+import com.hamster.gro_up.exception.ConflictException;
 
-public class DuplicateUserException extends BadRequestException {
+public class DuplicateUserException extends ConflictException {
     private static final String MESSAGE = "중복된 사용자가 존재합니다.";
 
     public DuplicateUserException() {super(MESSAGE);}

--- a/src/main/java/com/hamster/gro_up/service/AuthService.java
+++ b/src/main/java/com/hamster/gro_up/service/AuthService.java
@@ -207,4 +207,10 @@ public class AuthService {
 
         refreshTokenService.deleteRefreshToken(authUser.getEmail());
     }
+
+    public void checkEmailDuplicate(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new DuplicateUserException();
+        }
+    }
 }

--- a/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
+++ b/src/main/java/com/hamster/gro_up/service/EmailVerificationService.java
@@ -29,13 +29,8 @@ public class EmailVerificationService {
     private static final long VERIFICATION_CODE_TTL_MINUTES = 10L;
 
     public void sendVerificationCode(String email) {
-
-        if (userRepository.existsByEmail(email)) {
-            throw new DuplicateUserException("이미 가입된 이메일입니다.");
-        }
-
-        // 6자리 숫자 코드 생성
-        String code = String.format("%06d", new Random().nextInt(999999));
+        // 4자리 숫자 코드 생성
+        String code = String.format("%04d", new Random().nextInt(9999));
 
         // Redis 에 인증번호 저장 (key: email_verification:{email}, value: code)
         String key = VERIFICATION_PREFIX + email;

--- a/src/main/java/com/hamster/gro_up/util/TokenType.java
+++ b/src/main/java/com/hamster/gro_up/util/TokenType.java
@@ -1,7 +1,7 @@
 package com.hamster.gro_up.util;
 
 public enum TokenType {
-    ACCESS(3 * 60 * 1000L),         // 3분 TODO: 개발용으로 임시
+    ACCESS(60 * 60 * 1000L),         // 1시간
     REFRESH(14 * 24 * 60 * 60 * 1000L); // 2주
 
     private final long expireMs;

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -9,10 +9,7 @@ import com.hamster.gro_up.dto.request.SigninRequest;
 import com.hamster.gro_up.dto.request.SignupRequest;
 import com.hamster.gro_up.dto.response.TokenResponse;
 import com.hamster.gro_up.entity.Role;
-import com.hamster.gro_up.exception.auth.ExpiredTokenException;
-import com.hamster.gro_up.exception.auth.InvalidCredentialsException;
-import com.hamster.gro_up.exception.auth.InvalidEmailVerificationTokenException;
-import com.hamster.gro_up.exception.auth.TokenTypeMismatchException;
+import com.hamster.gro_up.exception.auth.*;
 import com.hamster.gro_up.exception.user.DuplicateUserException;
 import com.hamster.gro_up.exception.user.UserNotFoundException;
 import com.hamster.gro_up.service.AuthService;
@@ -35,8 +32,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(controllers = {AuthController.class})
@@ -138,7 +134,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("이메일 인증 코드 요청 시 이미 가입된 이메일이면 400을 반환한다")
+    @DisplayName("이메일 인증 코드 요청 시 이미 가입된 이메일이면 409를 반환한다")
     void sendVerificationCode_fail_duplicate() throws Exception {
         // given
         String email = "test@example.com";
@@ -148,8 +144,8 @@ class AuthControllerTest {
         // when & then
         mockMvc.perform(post("/api/auth/email/verify-request")
                         .param("email", email))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(409))
                 .andExpect(jsonPath("$.message").value("이미 가입된 이메일입니다."));
     }
 
@@ -321,7 +317,7 @@ class AuthControllerTest {
         PasswordCheckRequest request = new PasswordCheckRequest("password123");
 
         // when & then
-        mockMvc.perform(post("/api/auth/password-check")
+        mockMvc.perform(post("/api/auth/check-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -341,7 +337,7 @@ class AuthControllerTest {
         doThrow(new InvalidCredentialsException()).when(authService).checkPassword(any(AuthUser.class), any(PasswordCheckRequest.class));
 
         // when & then
-        mockMvc.perform(post("/api/auth/password-check")
+        mockMvc.perform(post("/api/auth/check-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
                 .andExpect(status().isUnauthorized())
@@ -398,16 +394,53 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value(404));
     }
 
+//    @Test
+//    @DisplayName("비밀번호 재설정에 성공한다")
+//    void reset_success() throws Exception {
+//        // given
+//        String token = "reset-token";
+//        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+//
+//        // when & then
+//        mockMvc.perform(post("/api/auth/reset-password")
+//                        .param("token", token)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(new ObjectMapper().writeValueAsString(request)))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.code").value(200))
+//                .andExpect(jsonPath("$.status").value("OK"))
+//                .andExpect(jsonPath("$.data").doesNotExist());
+//
+//        verify(authService).resetPasswordWithToken(eq(token), any(PasswordUpdateRequest.class));
+//    }
+
+//    @Test
+//    @DisplayName("만료된 토큰으로 비밀번호 재설정 시 401을 반환한다")
+//    void reset_fail_expiredToken() throws Exception {
+//        // given
+//        String token = "expired-token";
+//        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+//        doThrow(new ExpiredTokenException()).when(authService).resetPasswordWithToken(eq(token), any(PasswordUpdateRequest.class));
+//
+//        // when & then
+//        mockMvc.perform(post("/api/auth/reset-password")
+//                        .param("token", token)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(new ObjectMapper().writeValueAsString(request)))
+//                .andExpect(status().isUnauthorized())
+//                .andExpect(jsonPath("$.code").value(401));
+//    }
+
     @Test
     @DisplayName("비밀번호 재설정에 성공한다")
-    void reset_success() throws Exception {
+    void resetPasswordWithEmail_success() throws Exception {
         // given
-        String token = "reset-token";
+        String email = "ham@example.com";
         PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
 
         // when & then
         mockMvc.perform(post("/api/auth/reset-password")
-                        .param("token", token)
+                        .param("email", email)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -415,23 +448,88 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.data").doesNotExist());
 
-        verify(authService).resetPassword(eq(token), any(PasswordUpdateRequest.class));
+        verify(authService).resetPasswordWithEmail(eq(email), any(PasswordUpdateRequest.class));
     }
 
     @Test
-    @DisplayName("만료된 토큰으로 비밀번호 재설정 시 401을 반환한다")
-    void reset_fail_expiredToken() throws Exception {
+    @DisplayName("이메일 인증이 안 된 경우 403을 반환한다")
+    void resetPasswordWithEmail_fail_notVerified() throws Exception {
         // given
-        String token = "expired-token";
+        String email = "ham@example.com";
         PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
-        doThrow(new ExpiredTokenException()).when(authService).resetPassword(eq(token), any(PasswordUpdateRequest.class));
+        doThrow(new EmailNotVerifiedException()).when(authService).resetPasswordWithEmail(eq(email), any(PasswordUpdateRequest.class));
 
         // when & then
         mockMvc.perform(post("/api/auth/reset-password")
-                        .param("token", token)
+                        .param("email", email)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(request)))
-                .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.code").value(401));
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일로 비밀번호 재설정 시 404를 반환한다")
+    void resetPasswordWithEmail_fail_userNotFound() throws Exception {
+        // given
+        String email = "notfound@example.com";
+        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+        doThrow(new UserNotFoundException()).when(authService).resetPasswordWithEmail(eq(email), any(PasswordUpdateRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-password")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404));
+    }
+
+    @Test
+    @DisplayName("OAUTH 사용자가 비밀번호 재설정 시도 시 403을 반환한다")
+    void resetPasswordWithEmail_fail_notLocalUser() throws Exception {
+        // given
+        String email = "oauth@example.com";
+        PasswordUpdateRequest request = new PasswordUpdateRequest("newPassword123");
+        doThrow(new PasswordChangeNotAllowedException()).when(authService).resetPasswordWithEmail(eq(email), any(PasswordUpdateRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/reset-password")
+                        .param("email", email)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403));
+    }
+
+    @Test
+    @DisplayName("이메일 중복이 없으면 200 OK를 반환한다")
+    void checkEmailDuplicate_success() throws Exception {
+        // given
+        String email = "unique@example.com";
+
+        // when & then
+        mockMvc.perform(get("/api/auth/check-email")
+                        .param("email", email))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(authService).checkEmailDuplicate(email);
+    }
+
+    @Test
+    @DisplayName("이메일이 중복되면 409를 반환한다")
+    void checkEmailDuplicate_fail_duplicate() throws Exception {
+        // given
+        String email = "duplicate@example.com";
+        doThrow(new DuplicateUserException()).when(authService).checkEmailDuplicate(email);
+
+        // when & then
+        mockMvc.perform(get("/api/auth/check-email")
+                        .param("email", email))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(409));
     }
 }

--- a/src/test/java/com/hamster/gro_up/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/EmailVerificationServiceTest.java
@@ -55,7 +55,6 @@ class EmailVerificationServiceTest {
     void sendVerificationCode_success() {
         // given
         String email = "test@example.com";
-        given(userRepository.existsByEmail(email)).willReturn(false);
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
         // when
@@ -73,19 +72,6 @@ class EmailVerificationServiceTest {
         assertThat(message.getTo()).contains(email);
         assertThat(message.getSubject()).isEqualTo("이메일 인증 코드");
         assertThat(message.getText()).contains("인증 코드:");
-    }
-
-    @Test
-    @DisplayName("이미 가입된 이메일이면 예외가 발생한다")
-    void sendVerificationCode_fail_duplicate() {
-        // given
-        String email = "test@example.com";
-        given(userRepository.existsByEmail(email)).willReturn(true);
-
-        // when & then
-        assertThrows(DuplicateUserException.class, () -> emailVerificationService.sendVerificationCode(email));
-        verify(redisTemplate, never()).opsForValue();
-        verify(mailSender, never()).send(any(SimpleMailMessage.class));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
* 비밀번호 재설정 로직을 변경했습니다.
* 이메일 중복 검사 API 를 따로 구현했습니다.
* 인증 코드 6자리 -> 4자리
* 사용자 중복 예외 400 -> 409 변경
* 비밀번호 검증 url 을 변경했습니다. (`/password-check` -> `/check-password`)

## 작업 상세
### 비밀번호 재설정 로직(변경 전)
1. 이메일 입력
2. 이메일로 `비밀번호 재설정 url` + `?token=인증토큰` 발송
3. 비밀번호 재설정 url 로 넘어가서 비밀번호 입력
4. 비밀번호 재설정 API 호출(이때 토큰 검증도 함께 함)

### 비밀번호 재설정 로직(변경 후)
1. 이메일 입력
5. 이메일 인증 요청 API 호출
6. 해당 이메일로 인증 코드 발송 (4자리)
7. 인증 코드 검증 API 호출
8. 비밀번호 입력
9. 비밀번호 재설정 API 호출

## 관련 이슈
This closes #97 