### PR TITLE
feat: Refresh Token 쿠키 `SameSite=Lax` 설정 추가

### DIFF
--- a/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/hamster/gro_up/config/CustomOAuth2SuccessHandler.java
@@ -40,10 +40,9 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 
         ApiResponse<String> apiResponse = ApiResponse.of(HttpStatus.OK, accessToken);
 
-        Cookie refreshTokenCookie = CookieUtil.createRefreshTokenCookie(refreshToken);
-
         // Refresh Token 은 Cookie 에, Access Token 은 Body 에 담음
-        response.addCookie(refreshTokenCookie);
+        CookieUtil.addRefreshTokenCookie(response, refreshToken);
+
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));

--- a/src/main/java/com/hamster/gro_up/util/CookieUtil.java
+++ b/src/main/java/com/hamster/gro_up/util/CookieUtil.java
@@ -2,6 +2,8 @@ package com.hamster.gro_up.util;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh";
@@ -16,7 +18,7 @@ public class CookieUtil {
         return null;
     }
 
-    public static Cookie createExpiredCookie(String name) {
+    public static Cookie createExpiredRefreshTokenCookie(String name) {
         Cookie cookie = new Cookie(name, null);
         cookie.setMaxAge(0);
         cookie.setPath("/");
@@ -35,6 +37,28 @@ public class CookieUtil {
     }
 
     public static Cookie createRefreshTokenCookie(String refreshToken){
-        return CookieUtil.createCookie(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, refreshToken, 60 * 60 * 24 * 14); // 2주
+        return CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken, 60 * 60 * 24 * 14); // 2주
+    }
+
+    public static void addRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(60 * 60 * 24 * 14)
+                .sameSite("Lax")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void addExpiredRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie expiredCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        response.addHeader("Set-Cookie", expiredCookie.toString());
     }
 }

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -81,7 +81,8 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.data").value(token.getAccessToken()))
-                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")));
+                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")))
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")));
     }
 
     @Test
@@ -100,7 +101,8 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.data").value(token.getAccessToken()))
-                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")));
+                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")))
+                .andExpect(header().string("Set-Cookie", containsString("SameSite=Lax")));
     }
 
     @Test

--- a/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/AuthControllerTest.java
@@ -17,6 +17,7 @@ import com.hamster.gro_up.service.CustomOAuth2UserService;
 import com.hamster.gro_up.service.EmailVerificationService;
 import com.hamster.gro_up.util.CookieUtil;
 import com.hamster.gro_up.util.JwtUtil;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockCookie;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -68,7 +70,7 @@ class AuthControllerTest {
     void signUp_success() throws Exception {
         // given
         SignupRequest signupRequest = new SignupRequest("test@test.com", "password");
-        TokenResponse token = new TokenResponse("Access Token", "Refresh Token");
+        TokenResponse token = new TokenResponse("AccessToken", "RefreshToken");
         given(authService.signUp(any(SignupRequest.class))).willReturn(token);
 
         // when & then
@@ -79,7 +81,7 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.data").value(token.getAccessToken()))
-                .andExpect(cookie().value(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "Refresh Token"));
+                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")));
     }
 
     @Test
@@ -87,7 +89,7 @@ class AuthControllerTest {
     void signIn_success() throws Exception {
         // given
         SigninRequest signinRequest = new SigninRequest("test@test.com", "password");
-        TokenResponse token = new TokenResponse("Access Token", "Refresh Token");
+        TokenResponse token = new TokenResponse("AccessToken", "RefreshToken");
         given(authService.signIn(any(SigninRequest.class))).willReturn(token);
 
         // when & then
@@ -98,7 +100,7 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.data").value(token.getAccessToken()))
-                .andExpect(cookie().value(CookieUtil.REFRESH_TOKEN_COOKIE_NAME, "Refresh Token"));
+                .andExpect(header().string("Set-Cookie", containsString("refresh=RefreshToken")));
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
`SameSite=none` 으로 설정되어 있어 프론트엔드 테스트 환경에서 쿠키 저장에 어려움이 있었습니다.
이에 `SameSite=Lax` 설정을 추가하여 개발 및 테스트 환경에서의 쿠키 동작을 개선합니다.

## 작업 상세
* `CookieUtil`에서 `ResponseCookie`를 사용하여 `SameSite=Lax` 옵션을 명시적으로 추가했습니다.
* 관련 `AuthContrller` 및 `CustomOAuth2SuccessHandler` 에서 `HttpServletResponse.addCookie()` 대신 `CookieUtil.addRefreshTokenCookie()` , `CookieUtil.addExpiredRefreshTokenCookie()` 사용으로 변경하였습니다.
* 테스트 코드에서 쿠키의 `SameSite=Lax` 옵션 포함 여부를 검증하도록 수정했습니다.

## 관련 이슈
This closes #104 