### PR TITLE
fix: 일정 응답 DTO 에 `scheduleId` 추가

### DIFF
--- a/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
@@ -10,6 +10,8 @@ import java.time.LocalDateTime;
 @Getter
 public class ScheduleResponse {
 
+    private Long scheduleId;
+
     private Long companyId;
 
     private String companyName;
@@ -32,6 +34,7 @@ public class ScheduleResponse {
         Long companyId = (schedule.getCompany() != null) ? schedule.getCompany().getId() : null;
 
         return new ScheduleResponse(
+                schedule.getId(),
                 companyId,
                 schedule.getCompanyName(),
                 schedule.getCompanyLocation(),

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -64,7 +64,7 @@ class ScheduleControllerTest {
     void findSchedule_success() throws Exception {
         // given
         ScheduleResponse response = new ScheduleResponse(
-                10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
+                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
                 "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         given(scheduleService.findSchedule(any(), eq(100L))).willReturn(response);
@@ -99,11 +99,11 @@ class ScheduleControllerTest {
     void findAllSchedules_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
-                10L, "ham-corp", "DOCUMENT", "백엔드", "메모1",
+                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모1",
                 "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                11L, "egg-corp", "INTERVIEW", "프론트엔드", "메모2",
+                1L, 11L, "egg-corp", "INTERVIEW", "프론트엔드", "메모2",
                 "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));
@@ -129,7 +129,7 @@ class ScheduleControllerTest {
                 10L, "ham-corp", "서울", Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
         );
         ScheduleResponse response = new ScheduleResponse(
-                10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
+                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
                 "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         given(scheduleService.createSchedule(any(), any())).willReturn(response);
@@ -222,13 +222,13 @@ class ScheduleControllerTest {
     void getSchedulesByDateRange_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
-                1L, "ham-corp", "서울", "DOCUMENT", "백엔드", "메모",
+                1L, 1L, "ham-corp", "서울", "DOCUMENT", "백엔드", "메모",
                 LocalDateTime.of(2025, 5, 10, 10, 0),
                 LocalDateTime.of(2025, 5, 10, 11, 0),
                 LocalDateTime.of(2025, 5, 10, 10, 0)
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                2L, "ham-corp", "서울", "INTERVIEW", "프론트", "면접",
+                2L, 2L, "ham-corp", "서울", "INTERVIEW", "프론트", "면접",
                 LocalDateTime.of(2025, 5, 20, 14, 0),
                 LocalDateTime.of(2025, 5, 20, 15, 0),
                 LocalDateTime.of(2025, 5, 20, 14, 0)
@@ -294,11 +294,11 @@ class ScheduleControllerTest {
         // given
         String companyName = "네이버";
         ScheduleResponse schedule1 = new ScheduleResponse(
-                10L, companyName, "서울", "DOCUMENT", "백엔드", "메모1",
+                1L, 10L, companyName, "서울", "DOCUMENT", "백엔드", "메모1",
                 LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                10L, companyName, "서울", "INTERVIEW", "프론트엔드", "메모2",
+                2L, 10L, companyName, "서울", "INTERVIEW", "프론트엔드", "메모2",
                 LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));


### PR DESCRIPTION
## 작업 내용
`ScheduleResponse` 에 누락되어있던 `scheduleId`를 추가합니다.

## 관련 이슈
This closes #111 