### PR TITLE
feat: 일정 생성 및 기업 생성에 `상세주소` 도 받도록 추가

### DIFF
--- a/src/main/java/com/hamster/gro_up/dto/request/CompanyCreateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/CompanyCreateRequest.java
@@ -15,5 +15,7 @@ public class CompanyCreateRequest {
 
     private String url;
 
-    private String location;
+    private String address;
+
+    private String addressDetail;
 }

--- a/src/main/java/com/hamster/gro_up/dto/request/CompanyUpdateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/CompanyUpdateRequest.java
@@ -15,5 +15,7 @@ public class CompanyUpdateRequest {
 
     private String url;
 
-    private String location;
+    private String address;
+
+    private String addressDetail;
 }

--- a/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/ScheduleCreateRequest.java
@@ -17,7 +17,9 @@ public class ScheduleCreateRequest {
     @NotBlank
     private String companyName;
 
-    private String companyLocation;
+    private String address;
+
+    private String addressDetail;
 
     private Step step;
 

--- a/src/main/java/com/hamster/gro_up/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/com/hamster/gro_up/dto/request/ScheduleUpdateRequest.java
@@ -17,7 +17,9 @@ public class ScheduleUpdateRequest {
     @NotBlank
     private String companyName;
 
-    private String companyLocation;
+    private String address;
+
+    private String addressDetail;
 
     private Step step;
 

--- a/src/main/java/com/hamster/gro_up/dto/response/CompanyResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/CompanyResponse.java
@@ -18,7 +18,9 @@ public class CompanyResponse {
 
     private String url;
 
-    private String location;
+    private String address;
+
+    private String addressDetail;
 
     private LocalDateTime createdAt;
 
@@ -30,7 +32,8 @@ public class CompanyResponse {
                 company.getCompanyName(),
                 company.getPosition(),
                 company.getUrl(),
-                company.getLocation(),
+                company.getAddress(),
+                company.getAddressDetail(),
                 company.getCreatedAt(),
                 company.getModifiedAt()
         );

--- a/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hamster/gro_up/dto/response/ScheduleResponse.java
@@ -16,7 +16,9 @@ public class ScheduleResponse {
 
     private String companyName;
 
-    private String companyLocation;
+    private String address;
+
+    private String addressDetail;
 
     private String step;
 
@@ -37,7 +39,8 @@ public class ScheduleResponse {
                 schedule.getId(),
                 companyId,
                 schedule.getCompanyName(),
-                schedule.getCompanyLocation(),
+                schedule.getAddress(),
+                schedule.getAddressDetail(),
                 schedule.getStep().getDisplayName(),
                 schedule.getPosition(),
                 schedule.getMemo(),

--- a/src/main/java/com/hamster/gro_up/entity/Company.java
+++ b/src/main/java/com/hamster/gro_up/entity/Company.java
@@ -21,26 +21,30 @@ public class Company extends BaseEntity {
 
     private String url;
 
-    private String location;
+    private String address;
+
+    private String addressDetail;
 
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT), updatable = false, nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     @Builder
-    public Company(Long id, String companyName, String position, String url, String location, User user) {
+    public Company(Long id, String companyName, String position, String url, String address, String addressDetail, User user) {
         this.id = id;
         this.companyName = companyName;
         this.position = position;
         this.url = url;
-        this.location = location;
+        this.address = address;
+        this.addressDetail = addressDetail;
         this.user = user;
     }
 
-    public void update(String companyName, String position, String location, String url) {
+    public void update(String companyName, String position, String address, String addressDetail, String url) {
         this.companyName = companyName;
         this.position = position;
-        this.location = location;
+        this.address = address;
+        this.addressDetail = addressDetail;
         this.url = url;
     }
 

--- a/src/main/java/com/hamster/gro_up/entity/Schedule.java
+++ b/src/main/java/com/hamster/gro_up/entity/Schedule.java
@@ -32,14 +32,16 @@ public class Schedule extends BaseEntity {
 
     private String companyName;
 
-    private String companyLocation;
+    private String address;
+
+    private String addressDetail;
 
     @JoinColumn(name = "user_id", foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT), updatable = false, nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     @Builder
-    public Schedule(Long id, Step step, String position, LocalDateTime dueDate, String memo, Company company, String companyName, String companyLocation, User user) {
+    public Schedule(Long id, Step step, String position, LocalDateTime dueDate, String memo, Company company, String companyName, String address, String addressDetail, User user) {
         this.id = id;
         this.step = step;
         this.dueDate = dueDate;
@@ -47,14 +49,16 @@ public class Schedule extends BaseEntity {
         this.memo = memo;
         this.company = company;
         this.companyName = companyName;
-        this.companyLocation = companyLocation;
+        this.address = address;
+        this.addressDetail = addressDetail;
         this.user = user;
     }
 
-    public void update(Company company, String companyName, String companyLocation, LocalDateTime dueDate, String memo, String position, Step step) {
+    public void update(Company company, String companyName, String address, String addressDetail, LocalDateTime dueDate, String memo, String position, Step step) {
         this.company = company;
         this.companyName = companyName;
-        this.companyLocation = companyLocation;
+        this.address = address;
+        this.addressDetail = addressDetail;
         this.dueDate = dueDate;
         this.memo = memo;
         this.position = position;

--- a/src/main/java/com/hamster/gro_up/service/CompanyService.java
+++ b/src/main/java/com/hamster/gro_up/service/CompanyService.java
@@ -50,7 +50,8 @@ public class CompanyService {
                 .user(user)
                 .companyName(companyCreateRequest.getCompanyName())
                 .position(companyCreateRequest.getPosition())
-                .location(companyCreateRequest.getLocation())
+                .address(companyCreateRequest.getAddress())
+                .addressDetail(companyCreateRequest.getAddressDetail())
                 .url(companyCreateRequest.getUrl())
                 .build();
 
@@ -67,7 +68,8 @@ public class CompanyService {
 
         company.update(companyUpdateRequest.getCompanyName(),
                 companyUpdateRequest.getPosition(),
-                companyUpdateRequest.getLocation(),
+                companyUpdateRequest.getAddress(),
+                companyUpdateRequest.getAddressDetail(),
                 companyUpdateRequest.getUrl()
         );
     }

--- a/src/main/java/com/hamster/gro_up/service/ScheduleService.java
+++ b/src/main/java/com/hamster/gro_up/service/ScheduleService.java
@@ -52,19 +52,21 @@ public class ScheduleService {
     public ScheduleResponse createSchedule(AuthUser authUser, ScheduleCreateRequest request) {
         Company company = null;
         String companyName;
-        String companyLocation;
+        String address;
+        String addressDetail;
 
         if (request.getCompanyId() != null) {
-            company = companyRepository.findById(request.getCompanyId())
-                    .orElseThrow(CompanyNotFoundException::new);
+            company = companyRepository.findById(request.getCompanyId()).orElseThrow(CompanyNotFoundException::new);
 
             company.validateOwner(authUser.getId());
 
             companyName = company.getCompanyName();
-            companyLocation = company.getLocation();
+            address = company.getAddress();
+            addressDetail = company.getAddressDetail();
         } else {
             companyName = request.getCompanyName();
-            companyLocation = request.getCompanyLocation();
+            address = request.getAddress();
+            addressDetail = request.getAddressDetail();
         }
 
         User user = userRepository.findById(authUser.getId()).orElseThrow(UserNotFoundException::new);
@@ -73,7 +75,8 @@ public class ScheduleService {
                 .user(user)
                 .company(company)
                 .companyName(companyName)
-                .companyLocation(companyLocation)
+                .address(address)
+                .addressDetail(addressDetail)
                 .dueDate(request.getDueDate())
                 .step(request.getStep())
                 .position(request.getPosition())
@@ -92,10 +95,10 @@ public class ScheduleService {
         schedule.validateOwner(authUser.getId());
 
         Company company = null;
-
         Long companyId = scheduleUpdateRequest.getCompanyId();
         String companyName = scheduleUpdateRequest.getCompanyName();
-        String companyLocation = scheduleUpdateRequest.getCompanyLocation();
+        String address = scheduleUpdateRequest.getAddress();
+        String addressDetail = scheduleUpdateRequest.getAddressDetail();
 
         if (companyId != null) {
             company = companyRepository.findById(companyId).orElseThrow(CompanyNotFoundException::new);
@@ -103,13 +106,15 @@ public class ScheduleService {
             company.validateOwner(authUser.getId());
 
             companyName = company.getCompanyName();
-            companyLocation = company.getLocation();
+            address = company.getAddress();
+            addressDetail = company.getAddressDetail();
         }
 
         schedule.update(
                 company,
                 companyName,
-                companyLocation,
+                address,
+                addressDetail,
                 scheduleUpdateRequest.getDueDate(),
                 scheduleUpdateRequest.getMemo(),
                 scheduleUpdateRequest.getPosition(),

--- a/src/main/java/com/hamster/gro_up/util/TokenType.java
+++ b/src/main/java/com/hamster/gro_up/util/TokenType.java
@@ -1,8 +1,8 @@
 package com.hamster.gro_up.util;
 
 public enum TokenType {
-    ACCESS(60 * 60 * 1000L),         // 1시간
-    REFRESH(14 * 24 * 60 * 60 * 1000L); // 2주
+    ACCESS(14 * 24 * 60 * 60 * 1000L),  // 2주
+    REFRESH(2 * 14 * 24 * 60 * 60 * 1000L); // 4주
 
     private final long expireMs;
 

--- a/src/main/resources/db/migration/V11__add_address_to_schedule_and_company.sql
+++ b/src/main/resources/db/migration/V11__add_address_to_schedule_and_company.sql
@@ -1,0 +1,15 @@
+-- schedule 테이블: company_location -> address 로 컬럼명 변경
+ALTER TABLE schedule
+    CHANGE company_location address VARCHAR(255);
+
+-- schedule 테이블: address_detail 컬럼 추가
+ALTER TABLE schedule
+    ADD COLUMN address_detail VARCHAR(255) AFTER address;
+
+-- company 테이블: location -> address 로 컬럼명 변경
+ALTER TABLE company
+    CHANGE location address VARCHAR(255);
+
+-- company 테이블: address_detail 컬럼 추가
+ALTER TABLE company
+    ADD COLUMN address_detail VARCHAR(255) AFTER address;

--- a/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/CompanyControllerTest.java
@@ -62,7 +62,14 @@ class CompanyControllerTest {
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findCompany_success() throws Exception {
         // given
-        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
+        CompanyResponse response = new CompanyResponse(10L,
+                "ham-corp",
+                "back-end",
+                "www.ham.com",
+                "seoul",
+                "상세주소",
+                LocalDateTime.now(),
+                LocalDateTime.now());
         given(companyService.findCompany(any(), eq(10L))).willReturn(response);
 
         // when & then
@@ -79,8 +86,16 @@ class CompanyControllerTest {
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void createCompany_success() throws Exception {
         // given
-        CompanyCreateRequest request = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul");
-        CompanyResponse response = new CompanyResponse(10L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
+        CompanyCreateRequest request = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul", "상세주소");
+        CompanyResponse response = new CompanyResponse(
+                10L,
+                "ham-corp",
+                "back-end",
+                "www.ham.com",
+                "seoul",
+                "상세주소",
+                LocalDateTime.now(),
+                LocalDateTime.now());
         given(companyService.createCompany(any(), any())).willReturn(response);
 
         // when & then
@@ -99,7 +114,13 @@ class CompanyControllerTest {
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void updateCompany_success() throws Exception {
         // given
-        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "www.new.com", "busan");
+        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest(
+                "new-corp",
+                "front-end",
+                "www.new.com",
+                "busan",
+                "상세주소"
+        );
         willDoNothing().given(companyService).updateCompany(any(), eq(10L), any());
 
         // when & then
@@ -141,8 +162,25 @@ class CompanyControllerTest {
     @WithMockAuthUser(userId = 1L, email = "ham@example.com", role = Role.ROLE_USER)
     void findAllCompanies_success() throws Exception {
         // given
-        CompanyResponse company1 = new CompanyResponse(1L, "ham-corp", "back-end", "www.ham.com", "seoul", LocalDateTime.now(), LocalDateTime.now());
-        CompanyResponse company2 = new CompanyResponse(2L, "egg-corp", "front-end", "www.egg.com", "busan", LocalDateTime.now(), LocalDateTime.now());
+        CompanyResponse company1 = new CompanyResponse(
+                1L,
+                "ham-corp",
+                "back-end",
+                "www.ham.com",
+                "seoul",
+                "상세주소",
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+        CompanyResponse company2 = new CompanyResponse(
+                2L,
+                "egg-corp",
+                "front-end",
+                "www.egg.com",
+                "busan",
+                "상세주소",
+                LocalDateTime.now(),
+                LocalDateTime.now());
         CompanyListResponse companyListResponse = CompanyListResponse.of(List.of(company1, company2));
         given(companyService.findAllCompanies(any())).willReturn(companyListResponse);
 
@@ -182,9 +220,10 @@ class CompanyControllerTest {
         // given
         CompanyCreateRequest invalidRequest = new CompanyCreateRequest(
                 "",
-                "",
-                "",
-                ""
+                "back-end",
+                "ham-corp.test",
+                "주소",
+                "상세주소"
         );
 
         // when & then

--- a/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/hamster/gro_up/controller/ScheduleControllerTest.java
@@ -64,8 +64,17 @@ class ScheduleControllerTest {
     void findSchedule_success() throws Exception {
         // given
         ScheduleResponse response = new ScheduleResponse(
-                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
-                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                1L,
+                10L,
+                "ham-corp",
+                "서울",
+                "상세 주소",
+                "DOCUMENT",
+                "백엔드",
+                "메모",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
         given(scheduleService.findSchedule(any(), eq(100L))).willReturn(response);
 
@@ -99,12 +108,30 @@ class ScheduleControllerTest {
     void findAllSchedules_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
-                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모1",
-                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                1L,
+                10L,
+                "ham-corp",
+                "서울",
+                "상세주소",
+                "DOCUMENT",
+                "백엔드",
+                "메모1",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                1L, 11L, "egg-corp", "INTERVIEW", "프론트엔드", "메모2",
-                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                1L,
+                11L,
+                "egg-corp",
+                "서울",
+                "상세주소",
+                "INTERVIEW",
+                "프론트엔드",
+                "메모2",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
         ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));
         given(scheduleService.findAllSchedules(any())).willReturn(response);
@@ -126,11 +153,20 @@ class ScheduleControllerTest {
     void createSchedule_success() throws Exception {
         // given
         ScheduleCreateRequest request = new ScheduleCreateRequest(
-                10L, "ham-corp", "서울", Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
+                10L, "ham-corp", "서울", "상세주소", Step.DOCUMENT, LocalDateTime.now(), " 백엔드", "메모"
         );
         ScheduleResponse response = new ScheduleResponse(
-                1L, 10L, "ham-corp", "DOCUMENT", "백엔드", "메모",
-                "서울", LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
+                1L,
+                10L,
+                "ham-corp",
+                "서울",
+                "상세주소",
+                "DOCUMENT",
+                "백엔드",
+                "메모",
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                LocalDateTime.now()
         );
         given(scheduleService.createSchedule(any(), any())).willReturn(response);
 
@@ -151,7 +187,7 @@ class ScheduleControllerTest {
     void updateSchedule_success() throws Exception {
         // given
         ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
-                null, "test-corp", "test-location", Step.DOCUMENT, LocalDateTime.now(), "프론트엔드", "수정 메모"
+                null, "test-corp", "test-addrss", "test-addressDetail", Step.DOCUMENT, LocalDateTime.now(), "프론트엔드", "수정 메모"
         );
         willDoNothing().given(scheduleService).updateSchedule(any(), eq(100L), any());
 
@@ -199,6 +235,7 @@ class ScheduleControllerTest {
                 null,           // companyId
                 "",             // companyName (NotBlank 위반)
                 "서울",
+                "상세 주소",
                 null,           // step
                 null,           // dueDate
                 null,           // position
@@ -222,13 +259,13 @@ class ScheduleControllerTest {
     void getSchedulesByDateRange_success() throws Exception {
         // given
         ScheduleResponse schedule1 = new ScheduleResponse(
-                1L, 1L, "ham-corp", "서울", "DOCUMENT", "백엔드", "메모",
+                1L, 1L, "ham-corp", "서울", "상세주소", "DOCUMENT", "백엔드", "메모",
                 LocalDateTime.of(2025, 5, 10, 10, 0),
                 LocalDateTime.of(2025, 5, 10, 11, 0),
                 LocalDateTime.of(2025, 5, 10, 10, 0)
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                2L, 2L, "ham-corp", "서울", "INTERVIEW", "프론트", "면접",
+                2L, 2L, "ham-corp", "서울", "상세주소", "INTERVIEW", "프론트", "면접",
                 LocalDateTime.of(2025, 5, 20, 14, 0),
                 LocalDateTime.of(2025, 5, 20, 15, 0),
                 LocalDateTime.of(2025, 5, 20, 14, 0)
@@ -294,11 +331,11 @@ class ScheduleControllerTest {
         // given
         String companyName = "네이버";
         ScheduleResponse schedule1 = new ScheduleResponse(
-                1L, 10L, companyName, "서울", "DOCUMENT", "백엔드", "메모1",
+                1L, 10L, companyName, "서울", "상세주소", "DOCUMENT", "백엔드", "메모1",
                 LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleResponse schedule2 = new ScheduleResponse(
-                2L, 10L, companyName, "서울", "INTERVIEW", "프론트엔드", "메모2",
+                2L, 10L, companyName, "서울", "상세 주소", "INTERVIEW", "프론트엔드", "메모2",
                 LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now()
         );
         ScheduleListResponse response = ScheduleListResponse.of(List.of(schedule1, schedule2));

--- a/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/CompanyServiceTest.java
@@ -69,7 +69,7 @@ class CompanyServiceTest {
                 .user(user)
                 .companyName("ham-corp")
                 .position("back-end")
-                .location("seoul")
+                .address("seoul")
                 .url("www.ham.com")
                 .build();
     }
@@ -78,7 +78,7 @@ class CompanyServiceTest {
     @DisplayName("기업 등록에 성공한다")
     void createCompany_success() {
         // given
-        CompanyCreateRequest requestDto = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul");
+        CompanyCreateRequest requestDto = new CompanyCreateRequest("ham-corp", "back-end", "www.ham.com", "seoul", "상세주소");
         given(companyRepository.save(any(Company.class))).willReturn(company);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
 
@@ -89,7 +89,7 @@ class CompanyServiceTest {
         assertThat(companyResponse.getCompanyName()).isEqualTo("ham-corp");
         assertThat(companyResponse.getPosition()).isEqualTo("back-end");
         assertThat(companyResponse.getUrl()).isEqualTo("www.ham.com");
-        assertThat(companyResponse.getLocation()).isEqualTo("seoul");
+        assertThat(companyResponse.getAddress()).isEqualTo("seoul");
     }
 
     @Test
@@ -106,7 +106,7 @@ class CompanyServiceTest {
         assertThat(companyResponse.getCompanyName()).isEqualTo("ham-corp");
         assertThat(companyResponse.getPosition()).isEqualTo("back-end");
         assertThat(companyResponse.getUrl()).isEqualTo("www.ham.com");
-        assertThat(companyResponse.getLocation()).isEqualTo("seoul");
+        assertThat(companyResponse.getAddress()).isEqualTo("seoul");
     }
 
     @Test
@@ -127,7 +127,13 @@ class CompanyServiceTest {
     void updateCompany_success() {
         // given
         long companyId = 10L;
-        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "www.new.com", "busan");
+        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest(
+                "new-corp",
+                "front-end",
+                "www.new.com",
+                "busan",
+                "상세주소"
+        );
         given(companyRepository.findById(companyId)).willReturn(Optional.of(company));
 
         // when
@@ -136,7 +142,7 @@ class CompanyServiceTest {
         // then
         assertThat(company.getCompanyName()).isEqualTo("new-corp");
         assertThat(company.getPosition()).isEqualTo("front-end");
-        assertThat(company.getLocation()).isEqualTo("busan");
+        assertThat(company.getAddress()).isEqualTo("busan");
         assertThat(company.getUrl()).isEqualTo("www.new.com");
     }
 
@@ -145,7 +151,13 @@ class CompanyServiceTest {
     void updateCompany_fail_notOwner() {
         // given
         AuthUser otherAuthUser = new AuthUser(2L, "other-user", Role.ROLE_USER, UserType.LOCAL);
-        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest("new-corp", "front-end", "busan", "www.new.com");
+        CompanyUpdateRequest updateRequest = new CompanyUpdateRequest(
+                "new-corp",
+                "front-end",
+                "busan",
+                "www.new.com",
+                "상세주소"
+        );
         given(companyRepository.findById(10L)).willReturn(Optional.of(company));
 
         // when & then
@@ -191,7 +203,7 @@ class CompanyServiceTest {
                 .companyName("ham-corp")
                 .position("back-end")
                 .url("www.ham.com")
-                .location("seoul")
+                .address("seoul")
                 .build();
 
         Company company3 = Company.builder()
@@ -199,7 +211,7 @@ class CompanyServiceTest {
                 .companyName("egg-corp")
                 .position("front-end")
                 .url("www.egg.com")
-                .location("busan")
+                .address("busan")
                 .build();
 
         List<Company> companyList = List.of(company2, company3);

--- a/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
+++ b/src/test/java/com/hamster/gro_up/service/ScheduleServiceTest.java
@@ -73,7 +73,8 @@ class ScheduleServiceTest {
                 .user(user)
                 .companyName("ham-corp")
                 .position("back-end")
-                .location("seoul")
+                .address("seoul")
+                .addressDetail("상세주소")
                 .url("www.ham.com")
                 .build();
 
@@ -82,6 +83,8 @@ class ScheduleServiceTest {
                 .user(user)
                 .company(company)
                 .companyName(company.getCompanyName())
+                .address(company.getAddress())
+                .addressDetail(company.getAddressDetail())
                 .dueDate(LocalDateTime.of(2025, 5, 11, 12, 0))
                 .step(Step.DOCUMENT)
                 .position("백엔드")
@@ -177,7 +180,8 @@ class ScheduleServiceTest {
         ScheduleCreateRequest request = new ScheduleCreateRequest(
                 company.getId(),
                 company.getCompanyName(),
-                company.getLocation(),
+                company.getAddress(),
+                company.getAddressDetail(),
                 schedule.getStep(),
                 schedule.getDueDate(),
                 schedule.getPosition(),
@@ -207,7 +211,8 @@ class ScheduleServiceTest {
         ScheduleCreateRequest request = new ScheduleCreateRequest(
                 company.getId(),
                 company.getCompanyName(),
-                company.getLocation(),
+                company.getAddress(),
+                company.getAddressDetail(),
                 schedule.getStep(),
                 schedule.getDueDate(),
                 schedule.getPosition(),
@@ -228,7 +233,8 @@ class ScheduleServiceTest {
         ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
                 null,
                 "test-corp",
-                "test-location",
+                "test-address",
+                "test-addressDetail",
                 Step.DOCUMENT,
                 LocalDateTime.of(2025, 6, 12, 10, 0),
                 "프론트엔드",
@@ -242,7 +248,7 @@ class ScheduleServiceTest {
         // then
         assertThat(schedule.getCompany()).isNull();
         assertThat(schedule.getCompanyName()).isEqualTo(updateRequest.getCompanyName());
-        assertThat(schedule.getCompanyLocation()).isEqualTo(updateRequest.getCompanyLocation());
+        assertThat(schedule.getAddress()).isEqualTo(updateRequest.getAddress());
         assertThat(schedule.getDueDate()).isEqualTo(updateRequest.getDueDate());
         assertThat(schedule.getMemo()).isEqualTo(updateRequest.getMemo());
         assertThat(schedule.getPosition()).isEqualTo(updateRequest.getPosition());
@@ -257,7 +263,8 @@ class ScheduleServiceTest {
         ScheduleUpdateRequest updateRequest = new ScheduleUpdateRequest(
                 null,
                 "test-corp",
-                "test-location",
+                "test-address",
+                "test-addressDetail",
                 Step.DOCUMENT,
                 LocalDateTime.now(),
                 "백엔드",


### PR DESCRIPTION
## 작업 내용
일정 생성 및 기업 생성에 `상세주소`도 받도록 구현 및 테스트코드 수정을 하였습니다.

## 작업 상세
* 위치 변수명을 `location` 에서 `address` 로 변경하였습니다.
* 앞으로 일정 생성 및 기업 생성에 `address` , `address_detail` 을 받습니다.

## 관련 이슈
This closes #116 